### PR TITLE
[task-30] 강의 등록 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'com.vladmihalcea:hibernate-types-60:2.21.1'
     implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/hanahakdangserver/classroom/entity/Classroom.java
+++ b/src/main/java/com/hanahakdangserver/classroom/entity/Classroom.java
@@ -24,18 +24,19 @@ import com.hanahakdangserver.mixin.TimeBaseEntity;
 @Builder
 public class Classroom extends TimeBaseEntity {
 
-  // TODO: snowflake 생성기로 대체
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "mentor_id", nullable = false)
-  private User mentor;
+//  @ManyToOne(fetch = FetchType.LAZY)
+//  @JoinColumn(name = "mentor_id", nullable = false)
+//  private User mentor;
 
   @Column(nullable = false)
   @Builder.Default
   private Boolean isUsed = true;
 
+  public void updateIsUsed(Boolean isUsed) {
+    this.isUsed = isUsed;
+  }
 
 }

--- a/src/main/java/com/hanahakdangserver/classroom/utils/SnowFlakeGenerator.java
+++ b/src/main/java/com/hanahakdangserver/classroom/utils/SnowFlakeGenerator.java
@@ -1,0 +1,74 @@
+package com.hanahakdangserver.classroom.utils;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+import lombok.NoArgsConstructor;
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.IdentifierGenerator;
+import org.springframework.stereotype.Component;
+
+@NoArgsConstructor
+@Component
+public class SnowFlakeGenerator implements IdentifierGenerator {
+  private static final int CASE_ONE_BITS = 10;
+  private static final int CASE_TWO_BITS = 9;
+  private static final int SEQUENCE_BITS = 4; // 중복 방지용
+
+  private static final int maxSequence = (int) (Math.pow(2, CASE_ONE_BITS) - 1); // 2^5-1
+
+  private static final long CUSTOM_EPOCH = 1735657200000L; // 2025-01-01 00:00:00; 41bit
+  private volatile long sequence = 0L;
+  private int case_one = 10;
+  private int case_two = 0;
+  private volatile long lastTimestamp = -1L;
+
+  @Override
+  public Serializable generate(SharedSessionContractImplementor sharedSessionContractImplementor, Object o) throws HibernateException {
+    return nextId();
+  }
+
+  private static long timestamp() {
+    return Instant.now().toEpochMilli() - CUSTOM_EPOCH; // 41비트를 맞춰주기 위함
+  }
+
+  public synchronized long nextId() {
+    long currentTimestamp = timestamp();
+
+    if (currentTimestamp < lastTimestamp) {
+      throw new IllegalStateException("Invalid System Clock!");
+    }
+
+    // 동일한 시간에 들어온 요청으로 판단
+    if (currentTimestamp == lastTimestamp) {
+      sequence = (sequence + 1) & maxSequence;
+      if (sequence == 0) {
+        currentTimestamp = waitNextMillis(currentTimestamp);
+      }
+    } else {
+      sequence = 0;
+    }
+
+    lastTimestamp = currentTimestamp;
+    return makeId(currentTimestamp);
+  }
+
+  private Long makeId(long currentTimestamp) {
+    long id = 0;
+
+    id |= (currentTimestamp << CASE_ONE_BITS + CASE_TWO_BITS + SEQUENCE_BITS);
+    id |= (case_one << CASE_TWO_BITS + SEQUENCE_BITS);
+    id |= (case_two << SEQUENCE_BITS);
+    id |= sequence;
+
+    return id;
+  }
+
+  private long waitNextMillis(long currentTimestamp) {
+    while (currentTimestamp == lastTimestamp) {
+      currentTimestamp = timestamp();
+    }
+    return currentTimestamp;
+  }
+}

--- a/src/main/java/com/hanahakdangserver/config/SecurityConfig.java
+++ b/src/main/java/com/hanahakdangserver/config/SecurityConfig.java
@@ -2,8 +2,13 @@ package com.hanahakdangserver.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 
@@ -14,7 +19,14 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
+        .httpBasic(HttpBasicConfigurer::disable) // HTTP 기본 인증 비활성화
+        .csrf(CsrfConfigurer::disable) // CSRF 보호 비활성화
+        .formLogin(FormLoginConfigurer::disable) // 폼 로그인 비활성화; 임시
+        .logout(AbstractHttpConfigurer::disable) // 로그아웃 비활성화; 임시
         .authorizeHttpRequests((authorize) -> authorize
+            .requestMatchers("/lecture/register/**").permitAll()
+            .requestMatchers("/error/**", "/favicon.ico", "/**/*.png", "/**/*.gif", "/**/*.svg").permitAll() // 임시
+            .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
             .anyRequest().permitAll());
 
     return http.build();

--- a/src/main/java/com/hanahakdangserver/enrollment/entity/Enrollment.java
+++ b/src/main/java/com/hanahakdangserver/enrollment/entity/Enrollment.java
@@ -1,4 +1,4 @@
-package com.hanahakdangserver.lecture.enrollment.entity;
+package com.hanahakdangserver.enrollment.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/hanahakdangserver/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/hanahakdangserver/enrollment/repository/EnrollmentRepository.java
@@ -1,9 +1,9 @@
-package com.hanahakdangserver.lecture.enrollment.repository;
+package com.hanahakdangserver.enrollment.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.hanahakdangserver.lecture.enrollment.entity.Enrollment;
+import com.hanahakdangserver.enrollment.entity.Enrollment;
 
 @Repository
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {

--- a/src/main/java/com/hanahakdangserver/lecture/controller/LectureController.java
+++ b/src/main/java/com/hanahakdangserver/lecture/controller/LectureController.java
@@ -1,0 +1,53 @@
+package com.hanahakdangserver.lecture.controller;
+
+import java.util.List;
+
+import com.hanahakdangserver.lecture.dto.LectureRequest;
+import com.hanahakdangserver.lecture.service.LectureService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "강의", description = "강의 API 목록")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/lecture")
+public class LectureController {
+
+  private final LectureService lectureService;
+
+  /**
+   * 강의 엔티티 및 강의실 엔티티 생성 엔드포인트
+   * 추가) 이미지 S3 업로드
+   *
+   * @param imageFile 이미지 파일
+   * @param lectureRequest JSON
+   * @return "강의 생성 성공" 메시지
+   */
+
+  @Operation(summary = "강의 등록", description = "멘토가 강의를 생성하고 등록을 시도한다.")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "강의 등록 성공"),
+    @ApiResponse(responseCode = "404", description = "해당 카테고리가 존재하지 않습니다.")
+  })
+  @PostMapping
+  public ResponseEntity<String> registerNewLecture(
+      @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
+      @Valid @RequestPart(value = "data", required = false) LectureRequest lectureRequest
+  ) {
+
+    lectureService.registerNewLecture(imageFile, lectureRequest);
+
+    return ResponseEntity.ok("강의 생성 성공");
+  }
+}

--- a/src/main/java/com/hanahakdangserver/lecture/dto/LectureRequest.java
+++ b/src/main/java/com/hanahakdangserver/lecture/dto/LectureRequest.java
@@ -1,0 +1,53 @@
+package com.hanahakdangserver.lecture.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.hanahakdangserver.lecture.enums.LectureCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@ToString
+@Schema(description = "강의 등록 요청")
+public class LectureRequest {
+
+  @Schema(description = "강의 카테고리 ENUM", example = "FINANCIAL_PRODUCTS")
+  @NotNull(message = "유효하지 않은 카테고리가 입력되었습니다.")
+  private LectureCategory category;
+
+  @Schema(description = "강의 제목", example = "중일이와 함께하는 하나원큐앱 부시기")
+  @NotBlank(message = "제목은 반드시 입력해야 합니다.")
+  private String title;
+
+  @Schema(description = "강의 시작 시간", example = "2025-01-23 10:30:00")
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+  private LocalDateTime start_time;
+
+  @Schema(description = "강의 진행 시간", example = "2")
+  private Integer duration;
+
+  @Schema(description = "강의 수강을 위한 크레딧 비용", example = "2000")
+  private Integer price;
+
+  @Schema(description = "최대 수강 가능 인원", example = "4")
+  @NotNull(message = "최대 수강 가능 인원 수를 입력해주세요.")
+  private Integer max_participants;
+
+  @Schema(description = "강의 설명", example = "안녕하세요~ 여러분의 멘토 정중일입니다.")
+  private String description;
+
+  @Schema(description = "강의와 연관된 금융 상품 태그 ID 리스트", example = "[1, 2]")
+  private List<Integer> tags;
+}

--- a/src/main/java/com/hanahakdangserver/lecture/entity/Lecture.java
+++ b/src/main/java/com/hanahakdangserver/lecture/entity/Lecture.java
@@ -34,9 +34,9 @@ public class Lecture extends TimeBaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "mentor_id", nullable = false)
-  private User mentor;
+//  @ManyToOne(fetch = FetchType.LAZY)
+//  @JoinColumn(name = "mentor_id", nullable = false)
+//  private User mentor;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "classroom_id", nullable = false)
@@ -61,7 +61,7 @@ public class Lecture extends TimeBaseEntity {
   @Column(nullable = false)
   private Integer maxParticipants;
 
-  @Column(nullable = true)
+  @Column(columnDefinition = "text", nullable = true)
   private String description;
 
   @Convert(converter = IntegerListConverter.class)
@@ -73,7 +73,13 @@ public class Lecture extends TimeBaseEntity {
 
   @Column(nullable = false)
   @Builder.Default
+  private Boolean isFull = false;
+
+  @Column(nullable = false)
+  @Builder.Default
   private Boolean isCanceled = false;
 
-
+  public void updateIsFull(boolean isFull) {
+    this.isFull = isFull;
+  }
 }

--- a/src/main/java/com/hanahakdangserver/lecture/enums/LectureCategory.java
+++ b/src/main/java/com/hanahakdangserver/lecture/enums/LectureCategory.java
@@ -1,9 +1,14 @@
 package com.hanahakdangserver.lecture.enums;
 
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @RequiredArgsConstructor
+@Getter
 @ToString
 public enum LectureCategory {
 
@@ -16,4 +21,19 @@ public enum LectureCategory {
   STOCK_INVESTMENT("주식 투자");
 
   private final String description;
+
+  /**
+   * 입력되는 inputValue값과 일치하는 category가 있다면 LectureCategory 반환, 없다면 null 반환
+   * DTO에서 검증을 위해 추가한 역직렬화
+   *
+   * @param inputValue LectureCategory로 예상되는 문자열
+   * @return LectureCategory || null
+   */
+  @JsonCreator
+  public static LectureCategory parsing(String inputValue) {
+    return Stream.of(LectureCategory.values())
+        .filter(category -> category.name().equals(inputValue))
+        .findFirst()
+        .orElse(null);
+  }
 }

--- a/src/main/java/com/hanahakdangserver/lecture/repository/CategoryRepository.java
+++ b/src/main/java/com/hanahakdangserver/lecture/repository/CategoryRepository.java
@@ -1,5 +1,7 @@
 package com.hanahakdangserver.lecture.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,5 +10,5 @@ import com.hanahakdangserver.lecture.entity.Category;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-
+  Optional<Category> findByName(String name);
 }

--- a/src/main/java/com/hanahakdangserver/lecture/service/LectureService.java
+++ b/src/main/java/com/hanahakdangserver/lecture/service/LectureService.java
@@ -1,0 +1,60 @@
+package com.hanahakdangserver.lecture.service;
+
+import com.hanahakdangserver.classroom.entity.Classroom;
+import com.hanahakdangserver.classroom.repository.ClassroomRepository;
+import com.hanahakdangserver.classroom.utils.SnowFlakeGenerator;
+import com.hanahakdangserver.lecture.dto.LectureRequest;
+import com.hanahakdangserver.lecture.entity.Category;
+import com.hanahakdangserver.lecture.entity.Lecture;
+import com.hanahakdangserver.lecture.repository.CategoryRepository;
+import com.hanahakdangserver.lecture.repository.LectureRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class LectureService {
+
+  private final LectureRepository lectureRepository;
+  private final CategoryRepository categoryRepository;
+  private final ClassroomRepository classroomRepository;
+
+  private final SnowFlakeGenerator snowFlakeGenerator; // snowflake 생성기
+
+  /**
+   * 강의 객체와 강의실 객체를 생성한 후 DB에 저장합니다.
+   *
+   * @param lectureRequest 강의 생성 Request JSON
+   */
+  @Transactional
+  public void registerNewLecture(MultipartFile imgaeFile, LectureRequest lectureRequest) {
+
+    Long uniqueId = snowFlakeGenerator.nextId(); // 강의실에 대해 전역적으로 고유한 Id 생성
+
+    Classroom classroom = classroomRepository.save(
+        Classroom.builder().id(uniqueId).build()
+    ); // 연관된 강의실 생성 -> DB에 저장
+
+    Category category = categoryRepository.findByName(lectureRequest.getCategory().getDescription()).orElseThrow(() -> new EntityNotFoundException("해당 카테고리가 존재하지 않습니다."));
+
+//    TODO: 썸네일 이미지 S3에 업로드 처리 로직 추가 필요
+
+    lectureRepository.save(
+        Lecture.builder()
+              .classroom(classroom)
+              .category(category)
+              .title(lectureRequest.getTitle())
+              .startTime(lectureRequest.getStart_time())
+              .duration(lectureRequest.getDuration())
+              .price(lectureRequest.getPrice())
+              .maxParticipants(lectureRequest.getMax_participants())
+              .description(lectureRequest.getDescription())
+              .tagList(lectureRequest.getTags())
+            .build()
+    );
+  }
+}


### PR DESCRIPTION
## 변경사항

### AS-IS

강의 등록 API 구현했습니다.
- 강의 엔티티 생성 및 DB 저장
- 강의실 엔티티 생성 및 DB 저장
  - 강의실의 ID는 Snowflake로 생성

### TO-BE
특별히 repository 테스트 할 부분은 없어서 테스트 코드는 작성하지 않았습니다.


## 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [ ] 테스트 코드
- [x] API 테스트

## ETC.

썸네일 이미지 S3 업로드 로직은 추후 추가할 예정입니다. (아직 S3 버킷이 없어서... 팀장님이 안 주시네요)
또한 강의 엔티티에는 멘토 엔티티가 포함되어야 하지만 아직 유저 생성 로직이 완성되지 않은 관계로 일단 주석 처리하고 넘어갔습니다.
유저 생성 마무리 되면 UserDetails 추가하도록 하겠습니다.
