### PR TITLE
[Task-58] 검색 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'javax.mail:javax.mail-api:1.6.2'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     // AWS S3
     implementation platform('software.amazon.awssdk:bom:2.27.21')
     implementation 'software.amazon.awssdk:s3'

--- a/src/main/java/com/hanahakdangserver/config/WebClientConfig.java
+++ b/src/main/java/com/hanahakdangserver/config/WebClientConfig.java
@@ -1,0 +1,17 @@
+package com.hanahakdangserver.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+  @Bean
+  public WebClient.Builder webClientBuilder() {
+    return WebClient.builder()
+        .codecs(
+            configurer -> configurer.defaultCodecs().maxInMemorySize(10 * 1024 * 1024)); // 10MB로 설정
+  }
+}
+

--- a/src/main/java/com/hanahakdangserver/lecture/controller/LectureController.java
+++ b/src/main/java/com/hanahakdangserver/lecture/controller/LectureController.java
@@ -38,7 +38,7 @@ public class LectureController {
 
   @Operation(summary = "강의 등록", description = "멘토가 강의를 생성하고 등록을 시도한다.")
   @ApiResponses({
-      @ApiResponse(responseCode = "200", description = "강의 등록 성공"),
+      @ApiResponse(responseCode = "201", description = "강의 등록에 성공했습니다."),
       @ApiResponse(responseCode = "404", description = "해당 카테고리가 존재하지 않습니다.")
   })
   @PostMapping

--- a/src/main/java/com/hanahakdangserver/lecture/controller/LectureController.java
+++ b/src/main/java/com/hanahakdangserver/lecture/controller/LectureController.java
@@ -39,7 +39,8 @@ public class LectureController {
   @Operation(summary = "강의 등록", description = "멘토가 강의를 생성하고 등록을 시도한다.")
   @ApiResponses({
       @ApiResponse(responseCode = "201", description = "강의 등록에 성공했습니다."),
-      @ApiResponse(responseCode = "404", description = "해당 카테고리가 존재하지 않습니다.")
+      @ApiResponse(responseCode = "404", description = "해당 카테고리가 존재하지 않습니다."),
+      @ApiResponse(responseCode = "404", description = "해당 태그가 존재하지 않습니다.")
   })
   @PostMapping
   public ResponseEntity<ResponseDTO<Void>> registerNewLecture(

--- a/src/main/java/com/hanahakdangserver/lecture/dto/LectureRequest.java
+++ b/src/main/java/com/hanahakdangserver/lecture/dto/LectureRequest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -50,11 +51,12 @@ public class LectureRequest {
 
   @Schema(description = "최대 수강 가능 인원", example = "4")
   @NotNull(message = "최대 수강 가능 인원 수를 입력해주세요.")
+  @Max(value = 6, message = "최대 인원 수는 6명을 초과할 수 없습니다.")
   private Integer maxParticipants;
 
   @Schema(description = "강의 설명", example = "안녕하세요~ 여러분의 멘토 정중일입니다.")
   private String description;
 
   @Schema(description = "강의와 연관된 금융 상품 태그 ID 리스트", example = "[1, 2]")
-  private List<Integer> tags;
+  private List<Long> tags;
 }

--- a/src/main/java/com/hanahakdangserver/lecture/entity/Lecture.java
+++ b/src/main/java/com/hanahakdangserver/lecture/entity/Lecture.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/hanahakdangserver/lecture/entity/Lecture.java
+++ b/src/main/java/com/hanahakdangserver/lecture/entity/Lecture.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -22,7 +21,6 @@ import lombok.NoArgsConstructor;
 
 import com.hanahakdangserver.classroom.entity.Classroom;
 import com.hanahakdangserver.enrollment.entity.Enrollment;
-import com.hanahakdangserver.lecture.utils.IntegerListConverter;
 import com.hanahakdangserver.mixin.TimeBaseEntity;
 
 @Getter
@@ -67,9 +65,8 @@ public class Lecture extends TimeBaseEntity {
   @Column(columnDefinition = "text", nullable = true)
   private String description;
 
-  @Convert(converter = IntegerListConverter.class)
-  @Column(name = "tag_list", nullable = false)
-  private List<Integer> tagList;
+  @OneToMany(mappedBy = "lecture", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<LectureTag> tagList;
 
   @Column(nullable = true)
   private String thumbnailUrl;

--- a/src/main/java/com/hanahakdangserver/lecture/entity/Lecture.java
+++ b/src/main/java/com/hanahakdangserver/lecture/entity/Lecture.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/hanahakdangserver/lecture/entity/LectureTag.java
+++ b/src/main/java/com/hanahakdangserver/lecture/entity/LectureTag.java
@@ -1,0 +1,36 @@
+package com.hanahakdangserver.lecture.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.hanahakdangserver.product.entity.Tag;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+public class LectureTag {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "lecture_id", nullable = false)
+  private Lecture lecture;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "tag_id", nullable = false)
+  private Tag tag;
+}

--- a/src/main/java/com/hanahakdangserver/lecture/enums/LectureCategory.java
+++ b/src/main/java/com/hanahakdangserver/lecture/enums/LectureCategory.java
@@ -1,5 +1,8 @@
 package com.hanahakdangserver.lecture.enums;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -40,5 +43,18 @@ public enum LectureCategory {
         .filter(category -> category.name().equals(inputValue))
         .findFirst()
         .orElse(null);
+  }
+
+  /**
+   * description에 keyword가 포함된 LectureCategory 검색
+   *
+   * @param keyword 검색 키워드
+   * @return keyword를 포함하는 LectureCategory의 description을 List로 반환
+   */
+  public static List<String> getDescriptionContainsKeyword(String keyword) {
+    return Arrays.stream(LectureCategory.values())
+        .filter(category -> category.description.contains(keyword))
+        .map(LectureCategory::getDescription)
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/hanahakdangserver/lecture/enums/LectureResponseExceptionEnum.java
+++ b/src/main/java/com/hanahakdangserver/lecture/enums/LectureResponseExceptionEnum.java
@@ -9,6 +9,7 @@ import org.springframework.web.server.ResponseStatusException;
 @AllArgsConstructor
 public enum LectureResponseExceptionEnum {
   LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 강의가 존재하지 않습니다."),
+  TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 태그가 존재하지 않습니다."),
   CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리가 존재하지 않습니다.");
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/hanahakdangserver/lecture/repository/LectureRepositoryCustom.java
+++ b/src/main/java/com/hanahakdangserver/lecture/repository/LectureRepositoryCustom.java
@@ -27,4 +27,13 @@ public interface LectureRepositoryCustom {
    */
   Page<Lecture> searchAllCategoryLectures(PageRequest pageRequest,
       List<LectureCategory> categoryList);
+
+  /**
+   * 전달된 키워드를 포함하는 강의 목록을 반환
+   *
+   * @param pageRequest 페이지네이션을 위한 Pageable 구현체
+   * @param keyword     검색어
+   * @return Lecture 엔티티에 대한 검색 결과
+   */
+  Page<Lecture> searchWithKeyword(PageRequest pageRequest, String keyword);
 }

--- a/src/main/java/com/hanahakdangserver/lecture/repository/LectureTagRepository.java
+++ b/src/main/java/com/hanahakdangserver/lecture/repository/LectureTagRepository.java
@@ -1,0 +1,11 @@
+package com.hanahakdangserver.lecture.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.hanahakdangserver.lecture.entity.LectureTag;
+
+@Repository
+public interface LectureTagRepository extends JpaRepository<LectureTag, Long> {
+
+}

--- a/src/main/java/com/hanahakdangserver/lecture/service/LectureService.java
+++ b/src/main/java/com/hanahakdangserver/lecture/service/LectureService.java
@@ -63,6 +63,7 @@ public class LectureService {
     Category category = categoryRepository.findByName(lectureRequest.getCategory().getDescription())
         .orElseThrow(CATEGORY_NOT_FOUND::createResponseStatusException);
 
+    // TODO : 이미지 파일이 없을 경우 예외 처리 필요
     String thumbnailUrl = uploadImageFileToS3(imageFile);
 
     lectureRepository.save(

--- a/src/main/java/com/hanahakdangserver/news/controller/NewsController.java
+++ b/src/main/java/com/hanahakdangserver/news/controller/NewsController.java
@@ -1,0 +1,34 @@
+package com.hanahakdangserver.news.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hanahakdangserver.news.dto.NewsResponse;
+import com.hanahakdangserver.news.service.NewsService;
+
+import java.util.List;
+
+@Tag(name = "뉴스", description = "뉴스 API 목록")
+@RequiredArgsConstructor
+@RestController
+public class NewsController {
+
+  private final NewsService newsService;
+
+  @Operation(summary = "모든 뉴스 조회", description = "데이터베이스에 저장된 모든 뉴스를 조회한다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "뉴스 조회 성공"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @GetMapping("/news")
+  public ResponseEntity<List<NewsResponse>> getAllNews() {
+    List<NewsResponse> newsResponses = newsService.getAllNews();
+    return ResponseEntity.ok(newsResponses);
+  }
+}

--- a/src/main/java/com/hanahakdangserver/news/dto/NewsResponse.java
+++ b/src/main/java/com/hanahakdangserver/news/dto/NewsResponse.java
@@ -1,0 +1,25 @@
+package com.hanahakdangserver.news.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Schema(description = "뉴스 응답")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@ToString
+public class NewsResponse {
+
+  private Long id;
+  private String title;
+  private String content;
+  private String newsUrl;
+  private String newsThumbnailUrl;
+  private String createdAt;
+}

--- a/src/main/java/com/hanahakdangserver/news/entity/News.java
+++ b/src/main/java/com/hanahakdangserver/news/entity/News.java
@@ -1,6 +1,8 @@
 package com.hanahakdangserver.news.entity;
 
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -35,5 +37,8 @@ public class News {
 
   @Column(nullable = false)
   private String newsThumbnailUrl;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
 
 }

--- a/src/main/java/com/hanahakdangserver/news/repository/NewsRepository.java
+++ b/src/main/java/com/hanahakdangserver/news/repository/NewsRepository.java
@@ -1,0 +1,11 @@
+package com.hanahakdangserver.news.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.hanahakdangserver.news.entity.News;
+
+@Repository
+public interface NewsRepository extends JpaRepository<News, Long> {
+
+}

--- a/src/main/java/com/hanahakdangserver/news/service/NewsService.java
+++ b/src/main/java/com/hanahakdangserver/news/service/NewsService.java
@@ -1,0 +1,69 @@
+package com.hanahakdangserver.news.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+import com.hanahakdangserver.news.dto.NewsResponse;
+import com.hanahakdangserver.news.entity.News;
+import com.hanahakdangserver.news.repository.NewsRepository;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NewsService {
+
+  private final WebClient.Builder webClientBuilder;
+  private final NewsRepository newsRepository;
+
+  // Flask에서 데이터 가져오기
+  public List<Map<String, String>> fetchNewsFromPython() {
+    WebClient webClient = webClientBuilder.baseUrl("http://localhost:5001").build();
+    return webClient.get()
+        .uri("/news")
+        .retrieve()
+        .bodyToMono(List.class)
+        .block();
+  }
+
+  // 데이터베이스에 저장
+  @Transactional
+  public void saveNewsFromPython() {
+    List<Map<String, String>> articles = fetchNewsFromPython();
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+
+    for (Map<String, String> article : articles) {
+      LocalDateTime createdAt = LocalDateTime.parse(article.get("date"), formatter);
+      News news = News.builder()
+          .title(article.get("title"))
+          .content(article.get("content"))
+          .newsUrl(article.get("newsUrl"))
+          .newsThumbnailUrl(article.get("newsThumbnailUrl"))
+          .createdAt(createdAt)
+          .build();
+      newsRepository.save(news);
+    }
+  }
+
+  // 데이터베이스에서 모든 뉴스 조회
+  @Transactional(readOnly = true)
+  public List<NewsResponse> getAllNews() {
+    return newsRepository.findAll().stream()
+        .map(news -> NewsResponse.builder()
+            .id(news.getId())
+            .title(news.getTitle())
+            .content(news.getContent())
+            .newsUrl(news.getNewsUrl())
+            .newsThumbnailUrl(news.getNewsThumbnailUrl())
+            .createdAt(news.getCreatedAt().toString())
+            .build())
+        .toList();
+  }
+}

--- a/src/main/java/com/hanahakdangserver/news/util/NewsInitializer.java
+++ b/src/main/java/com/hanahakdangserver/news/util/NewsInitializer.java
@@ -1,0 +1,26 @@
+package com.hanahakdangserver.news.util;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.hanahakdangserver.news.service.NewsService;
+
+
+@Component
+public class NewsInitializer {
+
+  private final NewsService newsService;
+
+  public NewsInitializer(NewsService newsService) {
+    this.newsService = newsService;
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void initializeNewsData() {
+    newsService.saveNewsFromPython(); // Fetch news from Python and save to DB
+  }
+}

--- a/src/main/java/com/hanahakdangserver/product/entity/Tag.java
+++ b/src/main/java/com/hanahakdangserver/product/entity/Tag.java
@@ -1,15 +1,22 @@
 package com.hanahakdangserver.product.entity;
 
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.hanahakdangserver.lecture.entity.LectureTag;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,4 +31,7 @@ public class Tag {
 
   @Column(nullable = false, length = 255)
   private String tagName;
+
+  @OneToMany(mappedBy = "tag", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<LectureTag> lectureTagList;
 }

--- a/src/main/java/com/hanahakdangserver/product/repository/HanaItemRepository.java
+++ b/src/main/java/com/hanahakdangserver/product/repository/HanaItemRepository.java
@@ -20,6 +20,6 @@ public interface HanaItemRepository extends JpaRepository<HanaItem, Long> {
    * @return 해당 태그를 가진 HanaItem 리스트
    */
   @Query("SELECT h FROM HanaItem h WHERE h.tag.id IN :tagIds")
-  List<HanaItem> findAllByTagIds(@Param("tagIds") List<Integer> tagIds);
+  List<HanaItem> findAllByTagIds(@Param("tagIds") List<Long> tagIds);
 
 }

--- a/src/main/java/com/hanahakdangserver/product/repository/TagRepository.java
+++ b/src/main/java/com/hanahakdangserver/product/repository/TagRepository.java
@@ -1,9 +1,13 @@
 package com.hanahakdangserver.product.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.hanahakdangserver.product.entity.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
+  // tagName에 특정 문자열이 포함된 id 리스트 반환
+  List<Tag> findByTagNameContaining(String tagName);
 }

--- a/src/main/java/com/hanahakdangserver/product/service/HanaItemService.java
+++ b/src/main/java/com/hanahakdangserver/product/service/HanaItemService.java
@@ -9,9 +9,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.hanahakdangserver.lecture.entity.Lecture;
+import com.hanahakdangserver.lecture.entity.LectureTag;
 import com.hanahakdangserver.lecture.repository.LectureRepository;
 import com.hanahakdangserver.product.dto.HanaItemResponse;
 import com.hanahakdangserver.product.entity.HanaItem;
+import com.hanahakdangserver.product.entity.Tag;
 import com.hanahakdangserver.product.repository.HanaItemRepository;
 
 @Service
@@ -31,7 +33,10 @@ public class HanaItemService {
   public List<HanaItemResponse> getItemsByLectureId(Long lectureId) {
     Lecture lecture = lectureRepository.findById(lectureId)
         .orElseThrow(() -> new EntityNotFoundException("강의를 조회하지 못 했습니다"));
-    List<Integer> tagIds = lecture.getTagList(); // 강의 테이블에서 태그 리스트 가져오기
+
+    List<LectureTag> tagList = lecture.getTagList(); // 강의 테이블에서 태그 리스트 가져오기
+    List<Long> tagIds = tagList.stream().map(LectureTag::getTag).map(Tag::getId)
+        .collect(Collectors.toList());
 
     List<HanaItem> items = hanaItemRepository.findAllByTagIds(tagIds);
 

--- a/src/main/java/com/hanahakdangserver/search/controller/SearchController.java
+++ b/src/main/java/com/hanahakdangserver/search/controller/SearchController.java
@@ -1,0 +1,40 @@
+package com.hanahakdangserver.search.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hanahakdangserver.common.ResponseDTO;
+import com.hanahakdangserver.search.dto.SearchResponse;
+import com.hanahakdangserver.search.service.SearchService;
+import static com.hanahakdangserver.search.enums.SearchResponseSuccessEnum.GET_SEARCH_RESULT_SUCCESS;
+
+@Tag(name = "검색", description = "검색 API 목록")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/search")
+public class SearchController {
+
+  private final SearchService searchService;
+
+  @Operation(summary = "키워드 검색 결과 조회", description = "정보에 키워드를 포함하는 강의 목록 검색 결과를 조회할 수 있다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "검색 결과 조회에 성공했습니다.")
+  })
+  @GetMapping
+  public ResponseEntity<ResponseDTO<SearchResponse>> getSearchResult(
+      @RequestParam(value = "keyword") String keyword,
+      @RequestParam(value = "page", defaultValue = "0") Integer pageNum) {
+
+    SearchResponse searchResponse = searchService.getSearchResult(keyword, pageNum);
+
+    return GET_SEARCH_RESULT_SUCCESS.createResponseEntity(searchResponse);
+  }
+}

--- a/src/main/java/com/hanahakdangserver/search/dto/LectureResultDetailDTO.java
+++ b/src/main/java/com/hanahakdangserver/search/dto/LectureResultDetailDTO.java
@@ -1,0 +1,61 @@
+package com.hanahakdangserver.search.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Schema(description = "강의 검색 결과 상세 정보 응답")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@ToString
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class LectureResultDetailDTO {
+
+  @Schema(description = "강의 Id", example = "1")
+  private Long lectureId;
+
+  @Schema(description = "멘토 이름", example = "정중일")
+  private String mentorName;
+
+  @Schema(description = "강의 카테고리", example = "디지털 교육")
+  private String category;
+
+  @Schema(description = "강의 명칭", example = "정중일과 함께 하는 하나원큐앱 정복하기")
+  private String title;
+
+  @Schema(description = "강의 진행 시간", example = "2")
+  private Integer duration;
+
+  @Schema(description = "강의 시작시간", example = "2025-01-19 11:30:00")
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  private LocalDateTime startDate;
+
+  @Schema(description = "현재 수강신청한 인원", example = "4")
+  private Integer currParticipants;
+
+  @Schema(description = "수강신청 가능한 인원", example = "6")
+  private Integer maxParticipants;
+
+  @Schema(description = "수강신청 마감 여부", example = "false")
+  private Boolean isFull;
+
+  @Schema(description = "강의 썸네일 url", example = "www.hanaro-hanahakdang.com")
+  private String thumbnailImgUrl;
+}

--- a/src/main/java/com/hanahakdangserver/search/dto/SearchResponse.java
+++ b/src/main/java/com/hanahakdangserver/search/dto/SearchResponse.java
@@ -1,0 +1,29 @@
+package com.hanahakdangserver.search.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Schema(description = "검색 결과 조회 응답")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@ToString
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SearchResponse {
+
+  @Schema(description = "전체 검색 결과 개수", example = "20")
+  private Long totalCount;
+
+  @Schema(description = "검색 결과 목록")
+  private List<LectureResultDetailDTO> resultList;
+}

--- a/src/main/java/com/hanahakdangserver/search/enums/SearchResponseSuccessEnum.java
+++ b/src/main/java/com/hanahakdangserver/search/enums/SearchResponseSuccessEnum.java
@@ -1,0 +1,22 @@
+package com.hanahakdangserver.search.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.hanahakdangserver.common.ResponseDTO;
+
+@Getter
+@AllArgsConstructor
+public enum SearchResponseSuccessEnum {
+  GET_SEARCH_RESULT_SUCCESS(HttpStatus.OK, "검색 결과 조회에 성공했습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+
+  public <T> ResponseEntity<ResponseDTO<T>> createResponseEntity(T data) {
+    ResponseDTO<T> response = ResponseDTO.<T>builder().message(message).result(data).build();
+    return ResponseEntity.status(httpStatus).body(response);
+  }
+}

--- a/src/main/java/com/hanahakdangserver/search/service/SearchService.java
+++ b/src/main/java/com/hanahakdangserver/search/service/SearchService.java
@@ -1,0 +1,64 @@
+package com.hanahakdangserver.search.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hanahakdangserver.lecture.entity.Lecture;
+import com.hanahakdangserver.lecture.repository.LectureRepository;
+import com.hanahakdangserver.search.dto.LectureResultDetailDTO;
+import com.hanahakdangserver.search.dto.SearchResponse;
+
+@Log4j2
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class SearchService {
+
+  private final Integer PAGE_SIZE = 6;
+
+  private final LectureRepository lectureRepository;
+
+  public SearchResponse getSearchResult(String keyword, Integer pageNum) {
+
+    PageRequest pageRequest = PageRequest.of(pageNum, PAGE_SIZE);
+    Page<Lecture> searchResult = lectureRepository.searchWithKeyword(pageRequest, keyword);
+
+    List<LectureResultDetailDTO> lectureResultDetails = searchResult.getContent().stream().map(
+        result -> {
+          Integer currParticipants;
+
+          if (result.getIsFull()) {
+            currParticipants = result.getMaxParticipants();
+          } else {
+            // 연관된 enrollment의 개수를 계산
+            currParticipants = result.getEnrollments() != null
+                ? result.getEnrollments().size()
+                : 0;
+          }
+
+          return LectureResultDetailDTO.builder()
+              .lectureId(result.getId())
+              //              .mentorName(lecture.getMentor().getName())
+              .category(result.getCategory().getName())
+              .title(result.getTitle())
+              .startDate(result.getStartTime())
+              .duration(result.getDuration())
+              .currParticipants(currParticipants)
+              .maxParticipants(result.getMaxParticipants())
+              .isFull(result.getIsFull())
+              .thumbnailImgUrl(result.getThumbnailUrl())
+              .build();
+        }
+    ).collect(Collectors.toList());
+
+    return SearchResponse.builder().totalCount(searchResult.getTotalElements())
+        .resultList(lectureResultDetails).build();
+  }
+}

--- a/src/test/java/com/hanahakdangserver/faq/repository/FaqRepositoryTest.java
+++ b/src/test/java/com/hanahakdangserver/faq/repository/FaqRepositoryTest.java
@@ -4,6 +4,16 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.hanahakdangserver.classroom.entity.Classroom;
 import com.hanahakdangserver.classroom.repository.ClassroomRepository;
 import com.hanahakdangserver.config.ClockConfig;
@@ -16,15 +26,6 @@ import com.hanahakdangserver.lecture.repository.LectureRepository;
 import com.hanahakdangserver.user.entity.CareerInfo;
 import com.hanahakdangserver.user.repository.CareerInfoRepository;
 import com.hanahakdangserver.user.repository.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @Import({QueryDslConfig.class, ClockConfig.class}) // QueryDslConfig, ClockConfig를 가져옴
@@ -95,7 +96,6 @@ public class FaqRepositoryTest {
         .startTime(LocalDateTime.now())
         .duration(120)
         .maxParticipants(30)
-        .tagList(List.of(1, 2, 3))
         .build();
     lectureRepository.save(lecture);
 

--- a/src/test/java/com/hanahakdangserver/product/repository/HanaItemRepositoryTest.java
+++ b/src/test/java/com/hanahakdangserver/product/repository/HanaItemRepositoryTest.java
@@ -1,18 +1,17 @@
 package com.hanahakdangserver.product.repository;
 
-import com.hanahakdangserver.product.entity.HanaItem;
-import com.hanahakdangserver.product.entity.Tag;
+import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
+import com.hanahakdangserver.lecture.repository.LectureTagRepository;
+import com.hanahakdangserver.product.entity.HanaItem;
+import com.hanahakdangserver.product.entity.Tag;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -24,6 +23,9 @@ public class HanaItemRepositoryTest {
 
   @Autowired
   private TagRepository tagRepository;
+
+  @Autowired
+  private LectureTagRepository lectureTagRepository;
 
   private Tag tag1, tag2;
 
@@ -61,7 +63,7 @@ public class HanaItemRepositoryTest {
 //  @Test
   void testFindAllByTagIds() {
     // Given
-    List<Integer> tagIds = List.of(tag1.getId().intValue(), tag2.getId().intValue());
+    List<Long> tagIds = List.of(tag1.getId(), tag2.getId());
 
     // When
     List<HanaItem> items = hanaItemRepository.findAllByTagIds(tagIds);

--- a/src/test/java/com/hanahakdangserver/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/hanahakdangserver/review/repository/ReviewRepositoryTest.java
@@ -2,7 +2,13 @@ package com.hanahakdangserver.review.repository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 import com.hanahakdangserver.classroom.entity.Classroom;
 import com.hanahakdangserver.classroom.repository.ClassroomRepository;
@@ -16,12 +22,6 @@ import com.hanahakdangserver.review.entity.Review;
 import com.hanahakdangserver.user.entity.CareerInfo;
 import com.hanahakdangserver.user.repository.CareerInfoRepository;
 import com.hanahakdangserver.user.repository.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
 @DataJpaTest
 @Import({QueryDslConfig.class, ClockConfig.class}) // QueryDslConfig, ClockConfig를 가져옴
@@ -88,7 +88,6 @@ public class ReviewRepositoryTest {
         .startTime(LocalDateTime.now())
         .duration(120)
         .maxParticipants(20)
-        .tagList(List.of(1, 2, 3))
         .build();
     lectureRepository.save(lecture);
 


### PR DESCRIPTION
## 변경사항

### AS-IS

**검색 기능을 구현했습니다.**
Query Parameter로 keyword가 전달되면 해당 keyword를 포함하고 있는 강의 목록을 반환합니다.

keyword 조회 대상
- 강의 제목
- 강의 카테고리
- 강의 태그

강의에 해당하는 태그를 기존에는 리스트 형식으로 관리했지만(`[1, 2]`)
좀 더 원활한 검색을 위해
**`LECTURE_TAG`라는 테이블을 추가했습니다.**
`LECTURE_TAG`는 강의 id와 태그 id를 외래키로 갖고 있는 관계 테이블입니다.

### TO-BE

유저 기능 구현되면 멘토 이름도 조회하는 기능 추가할 예정입니다.

## 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [ ] 테스트 코드
- [x] API 테스트

## ETC.

`LECTURE_TAG`의 추가로 HanaItem 관련 로직도 수정이 되었습니다.
이에 따라 테스트 코드 역시 수정되었습니다.