### PR TITLE
:construction_worker: [task-53] 시큐리티를 활용한 세션 기반 로그인 구현

### DIFF
--- a/src/main/java/com/hanahakdangserver/auth/controller/AuthController.java
+++ b/src/main/java/com/hanahakdangserver/auth/controller/AuthController.java
@@ -62,17 +62,4 @@ public class AuthController {
     return EMAIL_CONFIRMED.createResponseEntity();
   }
 
-  /**
-   * 유저(멘토,멘티) 로그인
-   *
-   * @param loginRequest
-   * @return Ok 응답코드, message
-   */
-  @Operation(summary = "로그인 요청")
-  @PostMapping("/login")
-  public ResponseEntity<ResponseDTO<Object>> login(@Valid @RequestBody LoginRequest loginRequest) {
-//    return authService.login(loginRequest);
-    return LOG_IN_SUCCESS.createResponseEntity();
-  }
-
 }

--- a/src/main/java/com/hanahakdangserver/auth/enums/AuthResponseExceptionEnum.java
+++ b/src/main/java/com/hanahakdangserver/auth/enums/AuthResponseExceptionEnum.java
@@ -15,7 +15,8 @@ public enum AuthResponseExceptionEnum {
   PASSWORD_NOT_MATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
   EMAIL_CHECK_EXPIRED(HttpStatus.BAD_REQUEST, "이메일 인증 시간이 만료됐습니다."),
   EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "이메일을 찾을 수 없습니다."),
-  TOKEN_NOT_MATCHED(HttpStatus.BAD_REQUEST, "토큰이 일치하지 않습니다.");
+  TOKEN_NOT_MATCHED(HttpStatus.BAD_REQUEST, "토큰이 일치하지 않습니다."),
+  USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "아이디 또는 비밀번호가 맞지 않습니다. 다시 확인해주세요.");
 
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/hanahakdangserver/auth/security/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/hanahakdangserver/auth/security/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,38 @@
+package com.hanahakdangserver.auth.security;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import static com.hanahakdangserver.auth.enums.AuthResponseExceptionEnum.USER_NOT_FOUND;
+
+@Component
+public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+  /**
+   * 인증 실패 시 실행되는 핸들러.
+   * * 응답 바디에 로그인 실패 메시지를 작성하여 클라이언트에 전달한다.
+   */
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException exception) throws IOException {
+
+    String message = "";
+
+    if (exception instanceof BadCredentialsException) {
+      message = USER_NOT_FOUND.getMessage();
+    }
+
+    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write("{'message' :'" + message + "'}");
+  }
+}
+

--- a/src/main/java/com/hanahakdangserver/auth/security/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/hanahakdangserver/auth/security/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,34 @@
+package com.hanahakdangserver.auth.security;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import static com.hanahakdangserver.auth.enums.AuthResponseSuccessEnum.LOG_IN_SUCCESS;
+
+/**
+ * 인증 성공 시 실행되는 핸들러. 세션 ID를 기반으로 쿠키를 생성하여 응답 헤더에 추가한다. 응답 바디에 로그인 성공 메시지를 작성하여 클라이언트에 전달한다.
+ */
+@Component
+public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws IOException {
+
+    HttpSession session = request.getSession(true);
+
+    response.setHeader("Set-Cookie",
+        session.getId() + "; Path=/; HttpOnly; Secure;");
+    response.setStatus(HttpServletResponse.SC_OK);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write("{'message' :'" + LOG_IN_SUCCESS.getMessage() + "'}");
+
+  }
+}

--- a/src/main/java/com/hanahakdangserver/auth/security/CustomUserDetails.java
+++ b/src/main/java/com/hanahakdangserver/auth/security/CustomUserDetails.java
@@ -1,0 +1,62 @@
+package com.hanahakdangserver.auth.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+import com.hanahakdangserver.user.entity.User;
+
+/**
+ * Spring Security의 UserDetails 인터페이스를 구현하여 User 엔티티에 맞게 커스터마이징한 클래스
+ */
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+  private final User user;
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return user.getRole() == null ?
+        List.of() :
+        List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+  }
+
+  @Override
+  public String getPassword() {
+    return user.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+    return user.getEmail();
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  //회원 이용(탈퇴)상태
+  @Override
+  public boolean isEnabled() {
+    return user.getIsActive();
+  }
+
+  public User getUser() {
+    return user;
+  }
+}

--- a/src/main/java/com/hanahakdangserver/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/com/hanahakdangserver/auth/security/CustomUserDetailsService.java
@@ -1,0 +1,34 @@
+package com.hanahakdangserver.auth.security;
+
+import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hanahakdangserver.user.entity.User;
+import com.hanahakdangserver.user.repository.UserRepository;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CustomUserDetailsService implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    log.debug("로그인 시 입력받은 이메일 : {}", email);
+    Optional<User> user = userRepository.findByEmail(email);
+
+    if (user.isEmpty()) {
+      throw new UsernameNotFoundException("존재하지 않는 이메일입니다.");
+    }
+    return new CustomUserDetails(user.get());
+  }
+}

--- a/src/main/java/com/hanahakdangserver/auth/security/CustomUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/hanahakdangserver/auth/security/CustomUsernamePasswordAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package com.hanahakdangserver.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * 커스텀 인증 필터 클래스 Spring Security의 기본 UsernamePasswordAuthenticationFilter를 참고 JSON 형식으로 요청 데이터를 받고,
+ * 이메일을 사용자 이름(Username)으로 사용하는 방식으로 로그인 인증을 처리한다.
+ */
+public class CustomUsernamePasswordAuthenticationFilter extends
+    AbstractAuthenticationProcessingFilter {
+
+  private static final String CONTENT_TYPE = "application/json";
+  private static final String USERNAME_KEY = "email";
+  private static final String PASSWORD_KEY = "password";
+  private static final AntPathRequestMatcher DEFAULT_ANT_PATH_REQUEST_MATCHER = new AntPathRequestMatcher(
+      "/login", "POST");
+
+  private final ObjectMapper objectMapper;
+
+  public CustomUsernamePasswordAuthenticationFilter(ObjectMapper objectMapper) {
+    super(DEFAULT_ANT_PATH_REQUEST_MATCHER);
+    this.objectMapper = objectMapper;
+  }
+
+  /**
+   * 인증 시도 메서드. 클라이언트가 전송한 JSON 데이터를 읽어 사용자 인증 정보를 추출하고, 추출한 이메일과 비밀번호를 사용하여 인증을 시도한다.
+   * <p>
+   * 추가설명 : HTTP 요청의 본문(body)은 바이트 형식으로 전달. 따라서 문자열로 변환하기 위해 StreamUtils를 사용 변환된 문자열을
+   * objectMapper.readValue()를 통해 Map으로 파싱하여 클라이언트가 전송한 JSON 데이터를 처리
+   *
+   * @param request  HTTP 요청 객체
+   * @param response HTTP 응답 객체
+   * @return 인증된 사용자의 인증 토큰
+   */
+
+  @Override
+  public Authentication attemptAuthentication(HttpServletRequest request,
+      HttpServletResponse response) throws AuthenticationException, IOException {
+
+    if (!request.getMethod().equals("POST")) {
+      throw new AuthenticationServiceException(
+          "Authentication method not supported: " + request.getMethod());
+    }
+
+    if (request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)) {
+      throw new AuthenticationServiceException(
+          "Authentication Content-Type not supported: " + request.getContentType());
+    }
+
+    String messageBody = StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
+
+    Map<String, String> usernamePasswordMap = objectMapper.readValue(messageBody, Map.class);
+
+    String email = usernamePasswordMap.get(USERNAME_KEY);
+    String password = usernamePasswordMap.get(PASSWORD_KEY);
+
+    UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(email,
+        password);
+
+    return this.getAuthenticationManager().authenticate(authRequest);
+  }
+}

--- a/src/main/java/com/hanahakdangserver/config/AuthConfig.java
+++ b/src/main/java/com/hanahakdangserver/config/AuthConfig.java
@@ -1,9 +1,10 @@
 package com.hanahakdangserver.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
@@ -18,8 +19,9 @@ public class AuthConfig {
     return emailCheckHashKey;
   }
 
-  @Bean
-  public PasswordEncoder passwordEncoder() {
-    return new BCryptPasswordEncoder();
-  }
+
+  @Autowired
+  @Qualifier("securityPasswordEncoder")
+  private PasswordEncoder passwordEncoder;
+
 }

--- a/src/main/java/com/hanahakdangserver/config/SecurityConfig.java
+++ b/src/main/java/com/hanahakdangserver/config/SecurityConfig.java
@@ -1,31 +1,59 @@
 package com.hanahakdangserver.config;
 
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
-import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.hanahakdangserver.auth.security.CustomAuthenticationFailureHandler;
+import com.hanahakdangserver.auth.security.CustomAuthenticationSuccessHandler;
+import com.hanahakdangserver.auth.security.CustomUsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final ObjectMapper objectMapper;
+  private final UserDetailsService userDetailsService;
+  private final CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
+  private final CustomAuthenticationFailureHandler customAuthenticationFailureHandler;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
     http
+        .addFilterBefore(customJsonUsernamePasswordAuthenticationFilter(),
+            UsernamePasswordAuthenticationFilter.class)
         .httpBasic(HttpBasicConfigurer::disable) // HTTP 기본 인증 비활성화
         .csrf(CsrfConfigurer::disable) // CSRF 보호 비활성화
-        .formLogin(FormLoginConfigurer::disable) // 폼 로그인 비활성화; 임시
-        .logout(AbstractHttpConfigurer::disable) // 로그아웃 비활성화; 임시
+        .sessionManagement(session -> session
+            .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+        .logout(AbstractHttpConfigurer::disable) // 로그아웃 비활성화
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/swagger-ui/**")
             .permitAll()
-            .requestMatchers("/signup/**", "/check/**", "/send-email", "/verify-email")
+            .requestMatchers("/signup/**", "/check/**", "/send-email", "/verify-email", "/login")
             .permitAll()
             .requestMatchers("/lecture/**").permitAll() // TODO : 추후 authenticated로
             .requestMatchers("/lectures/**").permitAll() // TODO : 추후 authenticated로
@@ -36,5 +64,41 @@ public class SecurityConfig {
             .anyRequest().permitAll());
 
     return http.build();
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager() {
+    DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+    provider.setUserDetailsService(userDetailsService);
+    provider.setPasswordEncoder(passwordEncoder());
+    return new ProviderManager(provider);
+  }
+
+  @Bean
+  public CustomUsernamePasswordAuthenticationFilter customJsonUsernamePasswordAuthenticationFilter() {
+    CustomUsernamePasswordAuthenticationFilter filter = new CustomUsernamePasswordAuthenticationFilter(
+        objectMapper);
+    filter.setAuthenticationManager(authenticationManager());
+    filter.setAuthenticationSuccessHandler(customAuthenticationSuccessHandler);
+    filter.setAuthenticationFailureHandler(customAuthenticationFailureHandler);
+    return filter;
+  }
+
+  @Bean
+  @Qualifier("securityPasswordEncoder")
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.addAllowedOriginPattern("*");
+    configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Cache-Control"));
+    configuration.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE", "PUT"));
+    configuration.setAllowCredentials(true);
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,7 +17,9 @@ spring.mail.username=${MAIL_USERNAME}
 spring.mail.password=${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
-mail.expire-minute=5
+mail.expire-minute=51
+#security
+logging.level.org.springframework.security=DEBUG
 #---
 spring.config.activate.on-profile=local
 logging.level.com.hanahakdangserver=DEBUG


### PR DESCRIPTION
## 변경사항

### AS-IS

- 세션 로그인 구현에 필요한 security 커스텀
- 로그인 성공 시 응답 헤더 cookie에 session id를 반환

### TO-BE

[//]: # (해당 PR이 merge 되고 난 후 develop or main 브랜치에 줄 수 있는 영향 설명, 앞으로 할 작업 정리)

## 테스트

- [ ] 테스트 코드
- [Y] API 테스트

## ETC.
- 고민하다가 security 패키지는 일단 auth 안에 뒀고, 기능 별로(controller .. ) 따로 분리하진 않았습니다. 분리하는 게 더 나을 거 같다면 리뷰 부탁드립니다~ 리팩토링 후 올리겠습니다!