### PR TITLE
💪 [Task-62] 유저 인증 구현에 따른 강의 등록 로직 업데이트

### DIFF
--- a/src/main/java/com/hanahakdangserver/auth/controller/AuthController.java
+++ b/src/main/java/com/hanahakdangserver/auth/controller/AuthController.java
@@ -2,12 +2,15 @@ package com.hanahakdangserver.auth.controller;
 
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.hanahakdangserver.auth.dto.EmailCheckRequest;
@@ -55,10 +58,14 @@ public class AuthController {
   }
 
   @Operation(summary = "이메일 인증 확인 요청", description = "이메일로 전송된 링크를 통해 요청되는 확인 절차입니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "이메일 인증 성공"),
+      @ApiResponse(responseCode = "400", description = "이메일 인증이 완료되지 않았습니다.")
+  })
   @PostMapping("/verify-email")
-  public ResponseEntity<ResponseDTO<Object>> verifyEmail(
-      @Valid @RequestBody EmailConfirmRequest emailConfirmRequest) {
-    authService.verifyEmail(emailConfirmRequest);
+  public ResponseEntity<ResponseDTO<Object>> verifyEmail(@RequestParam String email,
+      @RequestParam String authToken) {
+    authService.verifyEmail(email, authToken);
     return EMAIL_CONFIRMED.createResponseEntity();
   }
 

--- a/src/main/java/com/hanahakdangserver/auth/security/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/hanahakdangserver/auth/security/CustomAuthenticationSuccessHandler.java
@@ -1,6 +1,7 @@
 package com.hanahakdangserver.auth.security;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,7 +42,9 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
     response.setCharacterEncoding("UTF-8");
 
     // 응답 JSON 객체 생성
-    Map<String, String> responseBody = Map.of("message", LOG_IN_SUCCESS.getMessage());
+    Map<String, Object> responseBody = new LinkedHashMap<>();
+    responseBody.put("message", LOG_IN_SUCCESS.getMessage());
+    responseBody.put("result", null);
 
     // JSON 문자열로 변환
     String jsonResponse = objectMapper.writeValueAsString(responseBody);

--- a/src/main/java/com/hanahakdangserver/auth/security/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/hanahakdangserver/auth/security/CustomAuthenticationSuccessHandler.java
@@ -1,11 +1,15 @@
 package com.hanahakdangserver.auth.security;
 
 import java.io.IOException;
+import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -14,8 +18,11 @@ import static com.hanahakdangserver.auth.enums.AuthResponseSuccessEnum.LOG_IN_SU
 /**
  * 인증 성공 시 실행되는 핸들러. 세션 ID를 기반으로 쿠키를 생성하여 응답 헤더에 추가한다. 응답 바디에 로그인 성공 메시지를 작성하여 클라이언트에 전달한다.
  */
+@RequiredArgsConstructor
 @Component
 public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+  private final ObjectMapper objectMapper;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -23,12 +30,23 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
 
     HttpSession session = request.getSession(true);
 
+    // 세션에 SecurityContext 저장
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+    session.setAttribute("SPRING_SECURITY_CONTEXT", SecurityContextHolder.getContext());
+
     response.setHeader("Set-Cookie",
         session.getId() + "; Path=/; HttpOnly; Secure;");
     response.setStatus(HttpServletResponse.SC_OK);
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");
-    response.getWriter().write("{'message' :'" + LOG_IN_SUCCESS.getMessage() + "'}");
+
+    // 응답 JSON 객체 생성
+    Map<String, String> responseBody = Map.of("message", LOG_IN_SUCCESS.getMessage());
+
+    // JSON 문자열로 변환
+    String jsonResponse = objectMapper.writeValueAsString(responseBody);
+
+    response.getWriter().write(jsonResponse);
 
   }
 }

--- a/src/main/java/com/hanahakdangserver/auth/security/CustomUserDetails.java
+++ b/src/main/java/com/hanahakdangserver/auth/security/CustomUserDetails.java
@@ -1,38 +1,47 @@
 package com.hanahakdangserver.auth.security;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
-
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import com.hanahakdangserver.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 /**
  * Spring Security의 UserDetails 인터페이스를 구현하여 User 엔티티에 맞게 커스터마이징한 클래스
  */
+@Builder
+@AllArgsConstructor
 @RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
 
-  private final User user;
+  @Getter
+  private Long id;
+  private String email;
+  private String password;
+  private Boolean isActive;
+  private final GrantedAuthority authority;
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    return user.getRole() == null ?
-        List.of() :
-        List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+    List<GrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(authority); // authority가 하나라고 가정
+
+    return authorities;
   }
 
   @Override
   public String getPassword() {
-    return user.getPassword();
+    return password;
   }
 
   @Override
   public String getUsername() {
-    return user.getEmail();
+    return email;
   }
 
   @Override
@@ -53,10 +62,7 @@ public class CustomUserDetails implements UserDetails {
   //회원 이용(탈퇴)상태
   @Override
   public boolean isEnabled() {
-    return user.getIsActive();
+    return isActive;
   }
 
-  public User getUser() {
-    return user;
-  }
 }

--- a/src/main/java/com/hanahakdangserver/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/com/hanahakdangserver/auth/security/CustomUserDetailsService.java
@@ -4,11 +4,11 @@ import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.hanahakdangserver.user.entity.User;
 import com.hanahakdangserver.user.repository.UserRepository;
@@ -16,19 +16,26 @@ import com.hanahakdangserver.user.repository.UserRepository;
 @Log4j2
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class CustomUserDetailsService implements UserDetailsService {
 
   private final UserRepository userRepository;
 
   @Override
   public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
     log.debug("로그인 시 입력받은 이메일 : {}", email);
     Optional<User> user = userRepository.findByEmail(email);
 
     if (user.isEmpty()) {
       throw new UsernameNotFoundException("존재하지 않는 이메일입니다.");
+    } else {
+      return CustomUserDetails.builder()
+          .id(user.get().getId())
+          .email(user.get().getEmail())
+          .password(user.get().getPassword())
+          .isActive(user.get().getIsActive())
+          .authority(new SimpleGrantedAuthority("ROLE_" + user.get().getRole().name()))
+          .build();
     }
-    return new CustomUserDetails(user.get());
   }
 }

--- a/src/main/java/com/hanahakdangserver/auth/service/AuthService.java
+++ b/src/main/java/com/hanahakdangserver/auth/service/AuthService.java
@@ -172,11 +172,13 @@ public class AuthService {
   /**
    * 이메일 인증 확인을 처리합니다. 레디스 해시에서 일치하는 이메일을 가져와 만료시간, 토큰 일치 여부에 따라 인증합니다.
    *
-   * @param emailConfirmRequest 이메일 인증 확인 요청
+   * @param email
+   * @param authToken
    * @throws ResponseStatusException 이메일 인증 실패 시 예외
    */
-  public void verifyEmail(EmailConfirmRequest emailConfirmRequest) throws ResponseStatusException {
-    String email = emailConfirmRequest.getEmail();
+
+  public void verifyEmail(String email, String authToken) throws ResponseStatusException {
+
     EmailCheckDTO emailCheckDTO = getEmailCheckDTO(email);
 
     LocalDateTime expireTime = emailCheckDTO.getExpireTime();
@@ -184,7 +186,7 @@ public class AuthService {
       throw EMAIL_CHECK_EXPIRED.createResponseStatusException();
     }
 
-    String receivedToken = emailConfirmRequest.getToken();
+    String receivedToken = authToken;
     String savedToken = emailCheckDTO.getToken();
     if (!receivedToken.equals(savedToken)) {
       throw TOKEN_NOT_MATCHED.createResponseStatusException();

--- a/src/main/java/com/hanahakdangserver/config/SecurityConfig.java
+++ b/src/main/java/com/hanahakdangserver/config/SecurityConfig.java
@@ -55,8 +55,8 @@ public class SecurityConfig {
             .permitAll()
             .requestMatchers("/signup/**", "/check/**", "/send-email", "/verify-email", "/login")
             .permitAll()
-            .requestMatchers("/lecture/**").permitAll() // TODO : 추후 authenticated로
-            .requestMatchers("/lectures/**").permitAll() // TODO : 추후 authenticated로
+            .requestMatchers("/lecture/**").hasRole("MENTOR")
+            .requestMatchers("/lectures/**").permitAll()
 //            .requestMatchers("/error/**", "/favicon.ico", "/**/*.png", "/**/*.gif", "/**/*.svg")
 //            .permitAll() // 임시
 //            .requestMatchers(HttpMethod.OPTIONS, "/**")

--- a/src/main/java/com/hanahakdangserver/email/service/EmailService.java
+++ b/src/main/java/com/hanahakdangserver/email/service/EmailService.java
@@ -25,10 +25,12 @@ public class EmailService {
 
       String htmlContent = "<html>" +
           "<body>" +
-          "<p>회원가입을 완료하려면 아래 링크를 클릭하세요✨</p>" +
-          "<a href='http://localhost:8080/verify-email?email=" + email
-          + "&authToken="
-          + authToken + "'>회원가입 인증</a>" +
+          "<p>회원가입을 완료하려면 아래 버튼을 클릭하세요✨</p>" +
+          "<form action='http://localhost:8080/verify-email' method='POST'>" +
+          "<input type='hidden' name='email' value='" + email + "' />" +
+          "<input type='hidden' name='authToken' value='" + authToken + "' />" +
+          "<button type='submit'>회원가입 인증</button>" +
+          "</form>" +
           "</body>" +
           "</html>";
       helper.setText(htmlContent, true);

--- a/src/main/java/com/hanahakdangserver/enrollment/entity/Enrollment.java
+++ b/src/main/java/com/hanahakdangserver/enrollment/entity/Enrollment.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 
 import com.hanahakdangserver.lecture.entity.Lecture;
 import com.hanahakdangserver.mixin.TimeBaseEntity;
+import com.hanahakdangserver.user.entity.User;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -32,10 +33,9 @@ public class Enrollment extends TimeBaseEntity {
   @JoinColumn(name = "lecture_id", nullable = false)
   private Lecture lecture;
 
-  //  TODO : UserDetails 엔티티 구현되면 적용할 예정
-//  @ManyToOne(fetch = FetchType.LAZY)
-//  @JoinColumn(name = "user_id", nullable = false)
-//  private User user;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
   @Column(nullable = false)
   @Builder.Default

--- a/src/main/java/com/hanahakdangserver/faq/entity/Faq.java
+++ b/src/main/java/com/hanahakdangserver/faq/entity/Faq.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 
 import com.hanahakdangserver.lecture.entity.Lecture;
 import com.hanahakdangserver.mixin.TimeBaseEntity;
+import com.hanahakdangserver.user.entity.User;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,9 +29,9 @@ public class Faq extends TimeBaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-//  @ManyToOne(fetch = FetchType.LAZY)
-//  @JoinColumn(name = "user_id", nullable = false)
-//  private User user;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "lecture_id")

--- a/src/main/java/com/hanahakdangserver/lecture/controller/LectureController.java
+++ b/src/main/java/com/hanahakdangserver/lecture/controller/LectureController.java
@@ -54,7 +54,7 @@ public class LectureController {
       @Valid @RequestPart(value = "data", required = false) LectureRequest lectureRequest
   ) throws IOException {
 
-    lectureService.registerNewLecture(userDetails.getUsername(), imageFile, lectureRequest);
+    lectureService.registerNewLecture(userDetails.getId(), imageFile, lectureRequest);
 
     return CREATE_LECTURE_SUCCESS.createResponseEntity(null);
   }

--- a/src/main/java/com/hanahakdangserver/lecture/controller/LectureController.java
+++ b/src/main/java/com/hanahakdangserver/lecture/controller/LectureController.java
@@ -8,18 +8,22 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.hanahakdangserver.auth.security.CustomUserDetails;
 import com.hanahakdangserver.common.ResponseDTO;
 import com.hanahakdangserver.lecture.dto.LectureRequest;
 import com.hanahakdangserver.lecture.service.LectureService;
 import static com.hanahakdangserver.lecture.enums.LectureResponseSuccessEnum.CREATE_LECTURE_SUCCESS;
 
+@Log4j2
 @Tag(name = "강의", description = "강의 API 목록")
 @RequiredArgsConstructor
 @RestController
@@ -40,17 +44,18 @@ public class LectureController {
   @ApiResponses({
       @ApiResponse(responseCode = "201", description = "강의 등록에 성공했습니다."),
       @ApiResponse(responseCode = "404", description = "해당 카테고리가 존재하지 않습니다."),
-      @ApiResponse(responseCode = "404", description = "해당 태그가 존재하지 않습니다.")
+      @ApiResponse(responseCode = "404", description = "해당 태그가 존재하지 않습니다."),
+      @ApiResponse(responseCode = "404", description = "해당 유저가 존재하지 않습니다.")
   })
   @PostMapping
   public ResponseEntity<ResponseDTO<Void>> registerNewLecture(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
       @Valid @RequestPart(value = "data", required = false) LectureRequest lectureRequest
   ) throws IOException {
 
-//    TODO : UserDetails 구현되면 유저 관련 추가 필요
-
-    lectureService.registerNewLecture(imageFile, lectureRequest);
+    log.info("###### UserDetails: {}", userDetails);
+    lectureService.registerNewLecture(userDetails.getUsername(), imageFile, lectureRequest);
 
     return CREATE_LECTURE_SUCCESS.createResponseEntity(null);
   }

--- a/src/main/java/com/hanahakdangserver/lecture/controller/LectureController.java
+++ b/src/main/java/com/hanahakdangserver/lecture/controller/LectureController.java
@@ -54,7 +54,6 @@ public class LectureController {
       @Valid @RequestPart(value = "data", required = false) LectureRequest lectureRequest
   ) throws IOException {
 
-    log.info("###### UserDetails: {}", userDetails);
     lectureService.registerNewLecture(userDetails.getUsername(), imageFile, lectureRequest);
 
     return CREATE_LECTURE_SUCCESS.createResponseEntity(null);

--- a/src/main/java/com/hanahakdangserver/lecture/entity/Lecture.java
+++ b/src/main/java/com/hanahakdangserver/lecture/entity/Lecture.java
@@ -22,6 +22,7 @@ import lombok.NoArgsConstructor;
 import com.hanahakdangserver.classroom.entity.Classroom;
 import com.hanahakdangserver.enrollment.entity.Enrollment;
 import com.hanahakdangserver.mixin.TimeBaseEntity;
+import com.hanahakdangserver.user.entity.User;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -34,10 +35,9 @@ public class Lecture extends TimeBaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  //  TODO : UserDetails 엔티티 구현되면 적용할 예정
-//  @ManyToOne(fetch = FetchType.LAZY)
-//  @JoinColumn(name = "mentor_id", nullable = false)
-//  private User mentor;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "mentor_id", nullable = false)
+  private User mentor;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "classroom_id", nullable = false)

--- a/src/main/java/com/hanahakdangserver/lecture/repository/LectureRepositoryImpl.java
+++ b/src/main/java/com/hanahakdangserver/lecture/repository/LectureRepositoryImpl.java
@@ -169,7 +169,9 @@ public class LectureRepositoryImpl implements LectureRepositoryCustom {
                 .select(lectureTag.lecture.id)
                 .from(lectureTag)
                 .where(lectureTag.tag.id.in(containedTags))
-        ));
+        ))
+        // 멘토명이 keyword를 포함하는지 검사
+        .or(lecture.mentor.name.containsIgnoreCase(keyword));
 
     List<Lecture> resultList = queryFactory
         .selectDistinct(lecture)

--- a/src/main/java/com/hanahakdangserver/lecture/service/LectureService.java
+++ b/src/main/java/com/hanahakdangserver/lecture/service/LectureService.java
@@ -96,7 +96,7 @@ public class LectureService {
     );
 
     // LECTURE_TAG에도 저장
-    for (Long tagId : lectureRequest.getTags()) {
+    lectureRequest.getTags().forEach(tagId -> {
       Tag tag = tagRepository.findById(tagId)
           .orElseThrow(TAG_NOT_FOUND::createResponseStatusException);
       lectureTagRepository.save(
@@ -105,7 +105,8 @@ public class LectureService {
               .tag(tag)
               .build()
       );
-    }
+    });
+
   }
 
   /**

--- a/src/main/java/com/hanahakdangserver/lecture/service/LectureService.java
+++ b/src/main/java/com/hanahakdangserver/lecture/service/LectureService.java
@@ -67,11 +67,11 @@ public class LectureService {
    * @param lectureRequest 강의 생성 Request JSON
    */
   @Transactional
-  public void registerNewLecture(String userEmail, MultipartFile imageFile,
+  public void registerNewLecture(Long userId, MultipartFile imageFile,
       LectureRequest lectureRequest)
       throws IOException {
 
-    User mentor = userRepository.findByEmail(userEmail)
+    User mentor = userRepository.findById(userId)
         .orElseThrow(USER_NOT_FOUND::createResponseStatusException);
 
     Long uniqueId = snowFlakeGenerator.nextId(); // 강의실에 대해 전역적으로 고유한 Id 생성

--- a/src/main/java/com/hanahakdangserver/lecture/service/LecturesService.java
+++ b/src/main/java/com/hanahakdangserver/lecture/service/LecturesService.java
@@ -103,7 +103,7 @@ public class LecturesService {
 
     return LectureDetailDTO.builder()
         .lectureId(lecture.getId())
-        //              .mentorName(lecture.getMentor().getName())
+        .mentorName(lecture.getMentor().getName())
         .category(lecture.getCategory().getName())
         .title(lecture.getTitle())
         .description(description)

--- a/src/main/java/com/hanahakdangserver/redis/RedisExceptionEnum.java
+++ b/src/main/java/com/hanahakdangserver/redis/RedisExceptionEnum.java
@@ -8,6 +8,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum RedisExceptionEnum {
+  ERROR_DURING_OPERATION("작업 중 오류가 발생했습니다."),
+  CANT_GET_VALUE("value를 가져올 수 없습니다."),
+  CANT_DELETE_BY_KEY("key를 통해 삭제할 수 없습니다."),
   CANT_CONVERT_INTO_JSON("json으로 변환할 수 없습니다."),
   CANT_CONVERT_INTO_DTO("객체로 변환할 수 없습니다.");
 

--- a/src/main/java/com/hanahakdangserver/redis/RedisString.java
+++ b/src/main/java/com/hanahakdangserver/redis/RedisString.java
@@ -1,0 +1,145 @@
+package com.hanahakdangserver.redis;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import static com.hanahakdangserver.redis.RedisExceptionEnum.CANT_DELETE_BY_KEY;
+import static com.hanahakdangserver.redis.RedisExceptionEnum.CANT_GET_VALUE;
+import static com.hanahakdangserver.redis.RedisExceptionEnum.ERROR_DURING_OPERATION;
+
+/**
+ * RedisTemplate<String, String>
+ */
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class RedisString {
+
+  private final RedisTemplate<String, String> redisTemplate;
+
+  /**
+   * Redis에 값을 저장
+   *
+   * @param key   저장할 키
+   * @param value 저장할 value
+   */
+  public void put(String key, String value) {
+    try {
+      log.debug("Putting {}-{} into Redis", key, value);
+      redisTemplate.opsForValue().set(key, value);
+    } catch (Exception e) {
+      log.error(ERROR_DURING_OPERATION.getMessage());
+    }
+  }
+
+  /**
+   * Redis에 값을 저장 + TTL 설정
+   *
+   * @param key      저장할 키
+   * @param value    저장할 value
+   * @param duration 설정할 TTL
+   */
+  public void putWithTTL(String key, String value, Duration duration) {
+    try {
+      log.debug("Putting {}-{} into Redis with TTL {}", key, value, duration);
+      redisTemplate.opsForValue().set(key, value, duration);
+    } catch (Exception e) {
+      log.error(ERROR_DURING_OPERATION.getMessage());
+    }
+  }
+
+  /**
+   * key를 통해 value를 가져옴
+   *
+   * @param key 키
+   * @return 가져온 값의 Optional
+   */
+  public Optional<String> get(String key) {
+    try {
+      String value = redisTemplate.opsForValue().get(key);
+      log.debug("Getting {}-{} from Redis", key, value);
+      return Optional.ofNullable(value);
+    } catch (Exception e) {
+      log.error(CANT_GET_VALUE.getMessage());
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * key로 삭제
+   *
+   * @param key 삭제할 키
+   * @return 삭제 성공 여부
+   */
+  public boolean delete(String key) {
+    try {
+      log.debug("Deleting {} from Redis", key);
+      Boolean result = redisTemplate.delete(key);
+      return Boolean.TRUE.equals(result);
+    } catch (Exception e) {
+      log.error(CANT_DELETE_BY_KEY.getMessage());
+      return false;
+    }
+  }
+
+  /**
+   * Redis에 키가 존재하는지 확인
+   *
+   * @param key 확인할 키
+   * @return 키 존재 여부
+   */
+  public boolean exists(String key) {
+    try {
+      log.debug("Checking existence of {} in Redis", key);
+      Boolean result = redisTemplate.hasKey(key);
+      return Boolean.TRUE.equals(result);
+    } catch (Exception e) {
+      log.error(ERROR_DURING_OPERATION.getMessage());
+      return false;
+    }
+  }
+
+  /**
+   * Redis에서 키의 값을 증가시킴. INCR 명령어 구현
+   *
+   * @param key   증가시킬 키
+   * @param delta 증가량 (양수)
+   * @return 증가된 값
+   */
+  public Long increment(String key, long delta) {
+    try {
+      log.debug("Incrementing {} by {} in Redis", key, delta);
+      Long newValue = redisTemplate.opsForValue().increment(key, delta);
+      log.debug("New value of {} is {}", key, newValue);
+      return newValue;
+    } catch (Exception e) {
+      log.error(ERROR_DURING_OPERATION.getMessage());
+      return null;
+    }
+  }
+
+  /**
+   * Redis에서 키의 값을 감소시킴. DECR 명령어 구현
+   *
+   * @param key   감소시킬 키
+   * @param delta 감소량 (양수음수)
+   * @return 감소된 값
+   */
+  public Long decrement(String key, long delta) {
+    try {
+      log.debug("Decrementing {} by {} in Redis", key, delta);
+      Long newValue = redisTemplate.opsForValue().increment(key, -delta);  // -delta로 감소시킴
+      log.debug("New value of {} is {}", key, newValue);
+      return newValue;
+    } catch (Exception e) {
+      log.error(ERROR_DURING_OPERATION.getMessage());
+      return null;
+    }
+  }
+
+}

--- a/src/main/java/com/hanahakdangserver/search/service/SearchService.java
+++ b/src/main/java/com/hanahakdangserver/search/service/SearchService.java
@@ -45,7 +45,7 @@ public class SearchService {
 
           return LectureResultDetailDTO.builder()
               .lectureId(result.getId())
-              //              .mentorName(lecture.getMentor().getName())
+              .mentorName(result.getMentor().getName())
               .category(result.getCategory().getName())
               .title(result.getTitle())
               .startDate(result.getStartTime())

--- a/src/main/java/com/hanahakdangserver/user/enums/UserResponseExceptionEnum.java
+++ b/src/main/java/com/hanahakdangserver/user/enums/UserResponseExceptionEnum.java
@@ -1,0 +1,20 @@
+package com.hanahakdangserver.user.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@Getter
+@AllArgsConstructor
+public enum UserResponseExceptionEnum {
+
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저가 존재하지 않습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+
+  public ResponseStatusException createResponseStatusException() {
+    return new ResponseStatusException(this.httpStatus, this.message);
+  }
+}

--- a/src/test/java/com/hanahakdangserver/faq/repository/FaqRepositoryTest.java
+++ b/src/test/java/com/hanahakdangserver/faq/repository/FaqRepositoryTest.java
@@ -24,6 +24,8 @@ import com.hanahakdangserver.lecture.entity.Lecture;
 import com.hanahakdangserver.lecture.repository.CategoryRepository;
 import com.hanahakdangserver.lecture.repository.LectureRepository;
 import com.hanahakdangserver.user.entity.CareerInfo;
+import com.hanahakdangserver.user.entity.User;
+import com.hanahakdangserver.user.enums.Role;
 import com.hanahakdangserver.user.repository.CareerInfoRepository;
 import com.hanahakdangserver.user.repository.UserRepository;
 
@@ -51,7 +53,9 @@ public class FaqRepositoryTest {
   private ClassroomRepository classroomRepository;
 
   private Lecture lecture;
-//  private User user;
+  private User mentor;
+  private User mentee;
+  ;
 
   @BeforeEach
   void setUp() {
@@ -70,16 +74,26 @@ public class FaqRepositoryTest {
         .build();
     categoryRepository.save(category);
 
-    // 유저 생성 및 저장
-//    user = User.builder()
-//        .name("Test User")
-//        .email("test@example.com")
-//        .password("password")
-//        .birthDate(LocalDate.of(1990, 5, 20))
-//        .role(Role.MENTEE)
-//        .careerInfo(careerInfo)
-//        .build();
-//    userRepository.save(user);
+    // 멘토 생성 및 저장
+    mentor = User.builder()
+        .name("Mentor User")
+        .email("test@example.com")
+        .password("password")
+        .birthDate(LocalDate.of(1990, 5, 20))
+        .role(Role.MENTEE)
+        .careerInfo(careerInfo)
+        .build();
+    userRepository.save(mentor);
+
+    // 멘티 생성 및 저장
+    mentee = User.builder()
+        .name("Mentee User")
+        .email("mentee@example.com")
+        .password("password")
+        .birthDate(LocalDate.of(1990, 8, 20))
+        .role(Role.MENTEE)
+        .build();
+    userRepository.save(mentee);
 
     // 강의실 생성 및 저장
     Classroom classroom = Classroom.builder()
@@ -90,7 +104,7 @@ public class FaqRepositoryTest {
     // 강의 생성 및 저장
     lecture = Lecture.builder()
         .title("Test Lecture")
-//        .mentor(user)
+        .mentor(mentor)
         .classroom(classroom)
         .category(category)
         .startTime(LocalDateTime.now())
@@ -102,7 +116,7 @@ public class FaqRepositoryTest {
     // FAQ 생성 및 저장
     Faq faq = Faq.builder()
         .lecture(lecture)
-//        .user(user)
+        .user(mentee)
         .content("강의는 무엇을 배우나요???")
         .build();
     faqRepository.save(faq);
@@ -119,6 +133,6 @@ public class FaqRepositoryTest {
     assertThat(faqs).isNotEmpty();
     assertThat(faqs.get(0).getContent()).isEqualTo("강의는 무엇을 배우나요???");
     assertThat(faqs.get(0).getLecture().getTitle()).isEqualTo("Test Lecture");
-//    assertThat(faqs.get(0).getUser().getName()).isEqualTo("Test User");
+    assertThat(faqs.get(0).getUser().getName()).isEqualTo("Mentee User");
   }
 }

--- a/src/test/java/com/hanahakdangserver/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/hanahakdangserver/review/repository/ReviewRepositoryTest.java
@@ -20,6 +20,8 @@ import com.hanahakdangserver.lecture.repository.CategoryRepository;
 import com.hanahakdangserver.lecture.repository.LectureRepository;
 import com.hanahakdangserver.review.entity.Review;
 import com.hanahakdangserver.user.entity.CareerInfo;
+import com.hanahakdangserver.user.entity.User;
+import com.hanahakdangserver.user.enums.Role;
 import com.hanahakdangserver.user.repository.CareerInfoRepository;
 import com.hanahakdangserver.user.repository.UserRepository;
 
@@ -47,8 +49,8 @@ public class ReviewRepositoryTest {
   private ClassroomRepository classroomRepository;
 
   private Lecture lecture;
-//  private User mentor;
-//  private User reviewer;
+  private User mentor;
+  private User reviewer;
 
   @BeforeEach
   void setUp() {
@@ -65,15 +67,15 @@ public class ReviewRepositoryTest {
         .build();
     categoryRepository.save(category);
 
-//    mentor = User.builder()
-//        .name("Mentor User")
-//        .email("mentor@example.com")
-//        .password("password")
-//        .birthDate(LocalDate.of(1985, 5, 15))
-//        .role(Role.MENTOR)
-//        .careerInfo(careerInfo) // CareerInfo 설정
-//        .build();
-//    userRepository.save(mentor);
+    mentor = User.builder()
+        .name("Mentor User")
+        .email("mentor@example.com")
+        .password("password")
+        .birthDate(LocalDate.of(1985, 5, 15))
+        .role(Role.MENTOR)
+        .careerInfo(careerInfo) // CareerInfo 설정
+        .build();
+    userRepository.save(mentor);
 
     Classroom classroom = Classroom.builder()
         .id(1L)
@@ -82,7 +84,7 @@ public class ReviewRepositoryTest {
 
     lecture = Lecture.builder()
         .title("금융 강의")
-//        .mentor(mentor)
+        .mentor(mentor)
         .classroom(classroom) // Classroom 설정
         .category(category)
         .startTime(LocalDateTime.now())
@@ -99,19 +101,19 @@ public class ReviewRepositoryTest {
         .build();
     careerInfoRepository.save(reviewerCareerInfo);
 
-//    reviewer = User.builder()
-//        .name("Review User")
-//        .email("reviewer@example.com")
-//        .password("password")
-//        .birthDate(LocalDate.of(1990, 8, 20))
-//        .role(Role.MENTEE)
-//        .careerInfo(reviewerCareerInfo) // CareerInfo 설정
-//        .build();
-//    userRepository.save(reviewer);
+    reviewer = User.builder()
+        .name("Review User")
+        .email("reviewer@example.com")
+        .password("password")
+        .birthDate(LocalDate.of(1990, 8, 20))
+        .role(Role.MENTEE)
+        .careerInfo(reviewerCareerInfo) // CareerInfo 설정
+        .build();
+    userRepository.save(reviewer);
 
     Review review = Review.builder()
         .lecture(lecture)
-//        .user(reviewer)
+        .user(reviewer)
         .content("훌륭한 강의었습니다.")
         .score(5)
         .build();


### PR DESCRIPTION
## 변경사항

### AS-IS

- **유저 로그인 시, authentication 정보가 session에 저장되지 않는 오류 수정하고 UserDetails 및 UserDetailsService 리팩토링 했습니다.**
  - SecurityConfig에 ROLE에 따라 엔드포인트 접근을 관리하는 부분을 추가했습니다.
  - `.requestMatchers("/lecture/**").hasRole("MENTOR")`
- **기존 강의 등록 로직에서 멘토 정보를 추가할 수 있도록 수정했습니다.**
  - 강의 등록 로직 외에도 엔티티에서 주석 처리하였던 유저 부분 주석 해제했습니다.
  - 이에 맞춰 테스트 코드도 수정했습니다.
  - 검색 API에서도 keyword를 포함하는 멘토 이름도 검색 결과에 추가하도록 수정했습니다.
- **강의 등록 직후 수강신청 인원 관리를 위해 Redis에 추가하는 로직을 구성했습니다.**
  - `redisString.putWithTTL(lectureKey, "0", ttlDuration);`
  - RedisString에서 <String, String> 데이터 타입에 대한 설정을 확인할 수 있습니다.
  - 동시성 이슈를 고려하여 레디스의 INCR 명령어를 활용할 예정입니다.

### TO-BE

앞으로 컨트롤러에서 로그인한 유저 정보가 필요한 경우 
클라이언트에게 `userId`를 요청하는 것이 아닌
**`@AuthenticationPrincipal CustomUserDetails userDetails`를 사용하도록 합니다.**

## 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [ ] 테스트 코드
- [x] API 테스트

## ETC.