### PR TITLE
:zap: [task-68] 파일 업로드 처리를 위한 S3 로직 분리, 계정 수정 api 기능

### DIFF
--- a/src/main/java/com/hanahakdangserver/auth/enums/AuthResponseExceptionEnum.java
+++ b/src/main/java/com/hanahakdangserver/auth/enums/AuthResponseExceptionEnum.java
@@ -12,7 +12,9 @@ import org.springframework.web.server.ResponseStatusException;
 public enum AuthResponseExceptionEnum {
   EMAIL_NOT_CONFIRMED(HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),
   EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "해당 이메일은 존재합니다."),
+  PASSWORD_BLANK(HttpStatus.BAD_REQUEST, "비밀번호를 입력해주세요."),
   PASSWORD_NOT_MATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+  NEW_PASSWORD_NOT_MATCHED(HttpStatus.BAD_REQUEST, "새 비밀번호가 일치하지 않습니다."),
   EMAIL_CHECK_EXPIRED(HttpStatus.BAD_REQUEST, "이메일 인증 시간이 만료됐습니다."),
   EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "이메일을 찾을 수 없습니다."),
   TOKEN_NOT_MATCHED(HttpStatus.BAD_REQUEST, "토큰이 일치하지 않습니다."),

--- a/src/main/java/com/hanahakdangserver/common/S3FileProcessor.java
+++ b/src/main/java/com/hanahakdangserver/common/S3FileProcessor.java
@@ -1,0 +1,83 @@
+package com.hanahakdangserver.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+@Log4j2
+@RequiredArgsConstructor
+@Component
+public class S3FileProcessor {
+
+  private final S3AsyncClient s3AsyncClient;
+
+  /**
+   * 이미지를 S3 버킷에 업로드 하고 url 주소를 받아오는 메서드
+   *
+   * @param imageFile 업로드할 이미지 파일
+   * @return S3에 업로드된 url 반환
+   * @throws IOException
+   */
+  public String uploadImageFileToS3(String bucket, MultipartFile imageFile)
+      throws IOException {
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+    try (InputStream inputStream = imageFile.getInputStream()) {
+      String originalFilename = imageFile.getOriginalFilename();
+      String uuid = UUID.randomUUID().toString();
+      String imageFileName = uuid + originalFilename;
+
+      PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+          .bucket(bucket)
+          .key(imageFileName)
+          .contentType(imageFile.getContentType())
+          .contentLength(imageFile.getSize())
+          .build();
+
+      // 파일 업로드 (비동기 처리)
+      CompletableFuture<PutObjectResponse> future = s3AsyncClient.putObject(
+          putObjectRequest,
+          AsyncRequestBody.fromInputStream(
+              inputStream,
+              imageFile.getSize(),
+              executorService
+          )
+      );
+
+      // 비동기 결과를 기다리고 응답 확인
+      PutObjectResponse response = future.join();
+
+      // 업로드 성공 여부 확인
+      if (response.sdkHttpResponse().isSuccessful()) {
+        // 업로드된 파일의 URL 가져오기
+        String imageUrl = String.format("https://%s.s3.%s.amazonaws.com/%s",
+            bucket,
+            Region.AP_NORTHEAST_2.toString().toLowerCase(),
+            imageFileName);
+        return imageUrl;
+
+      } else {
+        throw new RuntimeException(
+            "S3 업로드 실패: " + response.sdkHttpResponse().statusText().orElse("UNKNOWN ERROR"));
+      }
+
+    } catch (IOException e) {
+      log.warn("파일 업로드 실패: {}", e.getMessage());
+      throw new RuntimeException("S3 파일 업로드 중 오류 발생", e);
+    }
+  }
+
+}

--- a/src/main/java/com/hanahakdangserver/lecture/service/LectureManageService.java
+++ b/src/main/java/com/hanahakdangserver/lecture/service/LectureManageService.java
@@ -1,14 +1,9 @@
 package com.hanahakdangserver.lecture.service;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -16,15 +11,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import software.amazon.awssdk.core.async.AsyncRequestBody;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 import com.hanahakdangserver.classroom.entity.Classroom;
 import com.hanahakdangserver.classroom.repository.ClassroomRepository;
 import com.hanahakdangserver.classroom.utils.SnowFlakeGenerator;
+import com.hanahakdangserver.common.S3FileProcessor;
 import com.hanahakdangserver.lecture.dto.LectureRequest;
 import com.hanahakdangserver.lecture.entity.Category;
 import com.hanahakdangserver.lecture.entity.Lecture;
@@ -55,7 +46,7 @@ public class LectureManageService {
   private final UserRepository userRepository;
 
   private final SnowFlakeGenerator snowFlakeGenerator; // snowflake 생성기
-  private final S3AsyncClient s3AsyncClient;
+  private final S3FileProcessor s3FileProcessor;
   private final RedisString redisString;
 
   @Value("${aws.s3.bucketName}")
@@ -84,7 +75,7 @@ public class LectureManageService {
         .orElseThrow(CATEGORY_NOT_FOUND::createResponseStatusException);
 
     // TODO : 이미지 파일이 없을 경우 예외 처리 필요
-    String thumbnailUrl = uploadImageFileToS3(imageFile);
+    String thumbnailUrl = s3FileProcessor.uploadImageFileToS3(bucket, imageFile);
 
     Lecture lecture = lectureRepository.save(
         Lecture.builder()
@@ -127,58 +118,4 @@ public class LectureManageService {
     redisString.putWithTTL(lectureKey, "0", ttlDuration); // 수강신청한 인원 수 0으로 초기화
   }
 
-  /**
-   * 이미지를 S3 버킷에 업로드 하고 url 주소를 받아오는 메서드
-   *
-   * @param imageFile 업로드할 이미지 파일
-   * @return S3에 업로드된 url 반환
-   * @throws IOException
-   */
-  private String uploadImageFileToS3(MultipartFile imageFile) throws IOException {
-    ExecutorService executorService = Executors.newFixedThreadPool(10);
-
-    try (InputStream inputStream = imageFile.getInputStream()) {
-      String originalFilename = imageFile.getOriginalFilename();
-      String uuid = UUID.randomUUID().toString();
-      String imageFileName = uuid + originalFilename;
-
-      PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-          .bucket(bucket)
-          .key(imageFileName)
-          .contentType(imageFile.getContentType())
-          .contentLength(imageFile.getSize())
-          .build();
-
-      // 파일 업로드 (비동기 처리)
-      CompletableFuture<PutObjectResponse> future = s3AsyncClient.putObject(
-          putObjectRequest,
-          AsyncRequestBody.fromInputStream(
-              inputStream,
-              imageFile.getSize(),
-              executorService
-          )
-      );
-
-      // 비동기 결과를 기다리고 응답 확인
-      PutObjectResponse response = future.join();
-
-      // 업로드 성공 여부 확인
-      if (response.sdkHttpResponse().isSuccessful()) {
-        // 업로드된 파일의 URL 가져오기
-        String imageUrl = String.format("https://%s.s3.%s.amazonaws.com/%s",
-            bucket,
-            Region.AP_NORTHEAST_2.toString().toLowerCase(),
-            imageFileName);
-        return imageUrl;
-
-      } else {
-        throw new RuntimeException(
-            "S3 업로드 실패: " + response.sdkHttpResponse().statusText().orElse("UNKNOWN ERROR"));
-      }
-
-    } catch (IOException e) {
-      log.warn("파일 업로드 실패: {}", e.getMessage());
-      throw new RuntimeException("S3 파일 업로드 중 오류 발생", e);
-    }
-  }
 }

--- a/src/main/java/com/hanahakdangserver/user/controller/UserController.java
+++ b/src/main/java/com/hanahakdangserver/user/controller/UserController.java
@@ -1,0 +1,49 @@
+package com.hanahakdangserver.user.controller;
+
+import java.io.IOException;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.hanahakdangserver.auth.security.CustomUserDetails;
+import com.hanahakdangserver.common.ResponseDTO;
+import com.hanahakdangserver.user.dto.AccountRequest;
+import com.hanahakdangserver.user.service.UserService;
+import static com.hanahakdangserver.user.enums.UserResponseSuccessEnum.UPDATE_ACCOUNT_SUCCESS;
+
+@Log4j2
+@Tag(name = "유저 API", description = "유저 관련 api 목록")
+@RequiredArgsConstructor
+@RestController
+public class UserController {
+
+  private final UserService userService;
+
+  @Operation(summary = "계정 수정", description = "유저는 본인의 계정 수정을 시도한다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "계정 수정을 성공했습니다."),
+      @ApiResponse(responseCode = "400", description = "계정 수정에 실패했습니다.")
+  })
+  @PatchMapping("/account")
+  public ResponseEntity<ResponseDTO<Object>> updateProfileCard
+      (@RequestPart(value = "accountData", required = false) AccountRequest accountRequest,
+          @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
+          @AuthenticationPrincipal CustomUserDetails userDetails) throws IOException {
+
+    userService.updateAccount(userDetails.getId(), imageFile, accountRequest);
+
+    return UPDATE_ACCOUNT_SUCCESS.createResponseEntity();
+
+  }
+
+}

--- a/src/main/java/com/hanahakdangserver/user/dto/AccountRequest.java
+++ b/src/main/java/com/hanahakdangserver/user/dto/AccountRequest.java
@@ -1,0 +1,28 @@
+package com.hanahakdangserver.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Schema(description = "계정 정보 수정 요청")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@ToString
+public class AccountRequest {
+
+  @Schema(description = "현재 비밀번호", example = "1234")
+  private String currentPassword;
+
+  @Schema(description = "새 비밀번호", example = "5678")
+  private String newPassword;
+
+  @Schema(description = "새 비밀번호 확인", example = "5678")
+  private String confirmPassword;
+
+}

--- a/src/main/java/com/hanahakdangserver/user/entity/User.java
+++ b/src/main/java/com/hanahakdangserver/user/entity/User.java
@@ -59,4 +59,19 @@ public class User extends TimeBaseEntity {
   @Column(nullable = false)
   @Builder.Default
   private Boolean isActive = true;
+
+
+  public User update(String profileImageUrl, String newPassword) {
+    return User.builder()
+        .id(this.id)
+        .careerInfo(this.careerInfo)
+        .role(this.role)
+        .name(this.name)
+        .email(this.email)
+        .password(newPassword != null ? newPassword : this.password)
+        .birthDate(this.birthDate)
+        .profileImageUrl(profileImageUrl != null ? profileImageUrl : this.profileImageUrl)
+        .isActive(this.isActive)
+        .build();
+  }
 }

--- a/src/main/java/com/hanahakdangserver/user/enums/UserResponseSuccessEnum.java
+++ b/src/main/java/com/hanahakdangserver/user/enums/UserResponseSuccessEnum.java
@@ -1,0 +1,25 @@
+package com.hanahakdangserver.user.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.hanahakdangserver.common.ResponseDTO;
+
+
+@Getter
+@AllArgsConstructor
+public enum UserResponseSuccessEnum {
+  UPDATE_ACCOUNT_SUCCESS(HttpStatus.OK, "계정 수정에 성공했습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+
+
+  public ResponseEntity<ResponseDTO<Object>> createResponseEntity() {
+    ResponseDTO<Object> response = ResponseDTO.builder().message(message).build();
+    return ResponseEntity.status(httpStatus).body(response);
+  }
+
+}

--- a/src/main/java/com/hanahakdangserver/user/service/UserService.java
+++ b/src/main/java/com/hanahakdangserver/user/service/UserService.java
@@ -1,0 +1,76 @@
+package com.hanahakdangserver.user.service;
+
+import java.io.IOException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.hanahakdangserver.common.S3FileProcessor;
+import com.hanahakdangserver.user.dto.AccountRequest;
+import com.hanahakdangserver.user.entity.User;
+import com.hanahakdangserver.user.repository.UserRepository;
+import static com.hanahakdangserver.auth.enums.AuthResponseExceptionEnum.NEW_PASSWORD_NOT_MATCHED;
+import static com.hanahakdangserver.auth.enums.AuthResponseExceptionEnum.PASSWORD_BLANK;
+import static com.hanahakdangserver.auth.enums.AuthResponseExceptionEnum.PASSWORD_NOT_MATCHED;
+import static com.hanahakdangserver.user.enums.UserResponseExceptionEnum.USER_NOT_FOUND;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+
+public class UserService {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final S3FileProcessor s3FileProcessor;
+
+  @Value("${aws.s3.bucketName}")
+  private String bucket;
+
+  /**
+   * 계정 수정 기능(비밀번호, 프로필 이미지 변경)
+   */
+  @Transactional
+  public void updateAccount(Long userId, MultipartFile imageFile, AccountRequest accountRequest)
+      throws IOException {
+
+    String encodedPassword = null;
+    String profileImageUrl = null;
+    User currentUser = userRepository.findById(userId)
+        .orElseThrow(() -> USER_NOT_FOUND.createResponseStatusException());
+
+    //프로필 사진 변경을 요청한 경우
+    if (imageFile != null) {
+      profileImageUrl = s3FileProcessor.uploadImageFileToS3(bucket, imageFile);
+    }
+
+    //비밀번호 변경을 요청한 경우
+    if (accountRequest != null) {
+
+      if (accountRequest.getNewPassword().isEmpty() || accountRequest.getConfirmPassword()
+          .isEmpty()) {
+        throw PASSWORD_BLANK.createResponseStatusException();
+      }
+
+      if (!accountRequest.getNewPassword().equals(accountRequest.getConfirmPassword())) {
+        throw NEW_PASSWORD_NOT_MATCHED.createResponseStatusException();
+      }
+
+      if (!passwordEncoder.matches(accountRequest.getCurrentPassword(),
+          currentUser.getPassword())) {
+        throw PASSWORD_NOT_MATCHED.createResponseStatusException();
+      }
+
+      encodedPassword = passwordEncoder.encode(accountRequest.getConfirmPassword());
+    }
+
+    User user = currentUser.update(profileImageUrl, encodedPassword);
+    userRepository.save(user);
+  }
+}


### PR DESCRIPTION
## 변경사항

### AS-IS

- 계정 수정 api (비밀번호, 이미지 변경 가능)
- 이미지 업로드를 위해 s3관련 로직 분리했습니다.

## 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [ ] 테스트 코드
- [x] API 테스트
