### PR TITLE
Task 77 fix  usercard and email

### DIFF
--- a/src/main/java/com/hanahakdangserver/card/controller/CardController.java
+++ b/src/main/java/com/hanahakdangserver/card/controller/CardController.java
@@ -38,7 +38,7 @@ public class CardController {
       @ApiResponse(responseCode = "400", description = "명함이 존재하지 않습니다.")
   })
   @GetMapping("/profile-card/{userId}")
-  public ResponseEntity<ResponseDTO<Object>> getProfileCard(
+  public ResponseEntity<ResponseDTO<ProfileCardResponse>> getProfileCard(
       @PathVariable Long userId) {
     ProfileCardResponse cardResponse = cardService.get(userId);
     log.debug("result : {}",
@@ -53,7 +53,7 @@ public class CardController {
   })
   @PreAuthorize("isAuthenticated() and hasRole('MENTOR')")
   @GetMapping("/profile-card/me")
-  public ResponseEntity<ResponseDTO<Object>> getMyProfileCard(
+  public ResponseEntity<ResponseDTO<ProfileCardResponse>> getMyProfileCard(
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     ProfileCardResponse cardResponse = cardService.get(userDetails.getId());
     log.debug("result : {}",

--- a/src/main/java/com/hanahakdangserver/card/dto/ProfileCardResponse.java
+++ b/src/main/java/com/hanahakdangserver/card/dto/ProfileCardResponse.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @ToString
 public class ProfileCardResponse {
 
-  @Schema(description = "멘토 이름", example = "1")
+  @Schema(description = "멘토 이름", example = "미스터 중")
   private String mentor_name;
 
   @Schema(description = "프로필 사진 상단에 있는 짧은 자기소개", example = "안녕하세요 정중일 멘토입니다.")

--- a/src/main/java/com/hanahakdangserver/email/service/EmailService.java
+++ b/src/main/java/com/hanahakdangserver/email/service/EmailService.java
@@ -2,12 +2,15 @@ package com.hanahakdangserver.email.service;
 
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Log4j2
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -15,25 +18,20 @@ public class EmailService {
 
   private final JavaMailSender javaMailSender;
 
+  @Value("${front.port}")
+  private String port;
+
   @Async
   public void send(String email, String authToken) {
     MimeMessage mimeMessage = javaMailSender.createMimeMessage();
     try {
       MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true);
       helper.setTo(email);
-      helper.setSubject("하나학당 회원가입 인증 링크입니다.");
-
-      String htmlContent = "<html>" +
-          "<body>" +
-          "<p>회원가입을 완료하려면 아래 버튼을 클릭하세요✨</p>" +
-          "<form action='http://localhost:8080/verify-email' method='POST'>" +
-          "<input type='hidden' name='email' value='" + email + "' />" +
-          "<input type='hidden' name='authToken' value='" + authToken + "' />" +
-          "<button type='submit'>회원가입 인증</button>" +
-          "</form>" +
-          "</body>" +
-          "</html>";
-      helper.setText(htmlContent, true);
+      helper.setSubject("하나학당 회원가입 인증 링크입니다✨");
+//      String content = String.format("http://%s/verify-email?email=%s&authToken=%s", port,
+//          email, authToken);
+      String content = authToken; //임시
+      helper.setText(content, true);
 
       javaMailSender.send(mimeMessage);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,6 +26,7 @@ classroom.bound-key.mentee-id-set=classroom-mentees
 classroom.bound-key.prefix.token=cls-token
 classroom.interval-to-open-lecture=10
 notification.topic-name=notification
+front.port=${FRONT_PORT}
 #---
 spring.config.activate.on-profile=local
 logging.level.org.springframework.security=DEBUG


### PR DESCRIPTION
## 변경사항

### AS-IS
- 명함 조회 메서드 반환값 수정
- 이메일 발송 로직 수정

### TO-BE

- 프론트 도메인 나오면 주석처리한 링크로 진행할 예정입니다!
- 현재는 임시로 메일 내용을 authToken값이 나오도록 해놨습니다~

## 테스트


- [ ] 테스트 코드
- [x] API 테스트

## ETC.
- 스웨거에서 응답 예시가 제대로 나오지 않길래 코드 확인해봤는데, 반환 형식을 Object로 설정하고 안바꿔줘서 뜨지 않았던 것입니다..^^ 
- 인증링크는 프론트 도메인 나오면 후에 연결하려고 일단 주석처리 해놨습니다!
- 따라서 임시로 메일 내용을 authToken값이 나오도록 해놨습니다~