### PR TITLE
👋 [Task-94] 강의 종료 구현

### DIFF
--- a/src/main/java/com/hanahakdangserver/classroom/controller/ClassroomController.java
+++ b/src/main/java/com/hanahakdangserver/classroom/controller/ClassroomController.java
@@ -24,6 +24,7 @@ import com.hanahakdangserver.classroom.service.ClassroomService;
 import com.hanahakdangserver.common.ResponseDTO;
 import static com.hanahakdangserver.classroom.enums.ClassroomResponseSuccessEnum.CLASSROOM_ENTERED;
 import static com.hanahakdangserver.classroom.enums.ClassroomResponseSuccessEnum.CLASSROOM_STARTED;
+import static com.hanahakdangserver.classroom.enums.ClassroomResponseSuccessEnum.CLASSROOM_TERMINATED;
 
 @Tag(name = "강의실", description = "강의실 API")
 @Log4j2
@@ -73,5 +74,20 @@ public class ClassroomController {
     ClassroomEnterResponse enterResponse = classroomService.enterClassroom(classroomId,
         userDetails.getId());
     return CLASSROOM_ENTERED.createResponseEntity(enterResponse);
+  }
+
+  @Operation(summary = "강의 종료", description = "멘토가 강의를 종료합니다. 이후 웹소켓, WebRTC 연결도 해제됩니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "강의 종료에 성공했습니다."),
+      @ApiResponse(responseCode = "404", description = "강의 정보를 찾을 수 없습니다", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseDTO.class)),
+      }),
+  })
+  @PostMapping("/{classroomId}/terminate")
+  @PreAuthorize("hasRole('MENTOR')")
+  public ResponseEntity<ResponseDTO<Void>> terminate(@PathVariable Long classroomId) {
+    log.info("Terminate classroom with id {}", classroomId);
+    classroomService.terminateClassroom(classroomId);
+    return CLASSROOM_TERMINATED.createResponseEntity(null);
   }
 }

--- a/src/main/java/com/hanahakdangserver/classroom/enums/ClassroomResponseSuccessEnum.java
+++ b/src/main/java/com/hanahakdangserver/classroom/enums/ClassroomResponseSuccessEnum.java
@@ -11,7 +11,8 @@ import com.hanahakdangserver.common.ResponseDTO;
 @RequiredArgsConstructor
 public enum ClassroomResponseSuccessEnum {
   CLASSROOM_STARTED(HttpStatus.OK, "강의를 시작합니다"),
-  CLASSROOM_ENTERED(HttpStatus.OK, "강의실에 입장합니다.");
+  CLASSROOM_ENTERED(HttpStatus.OK, "강의실에 입장합니다."),
+  CLASSROOM_TERMINATED(HttpStatus.OK, "강의 종료에 성공했습니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/com/hanahakdangserver/classroom/service/ClassroomService.java
+++ b/src/main/java/com/hanahakdangserver/classroom/service/ClassroomService.java
@@ -83,7 +83,6 @@ public class ClassroomService {
     Lecture lecture = lectureRepository.findById(lectureId)
         .orElseThrow(NOT_FOUND_LECTURE::createResponseStatusException);
 
-    log.debug("강의: {}", lecture);
     if (lecture.getIsCanceled()) {
       throw LECTURE_CANCELED.createResponseStatusException();
     }


### PR DESCRIPTION
## 변경사항

### AS-IS

멘토가 강의 종료하는 API 구현했습니다.
- 강의 엔티티의 endTime 현재 시각으로 업데이트
- 레디스에서 관련된 데이터 삭제

웹소켓 연결 해지는 클라이언트 측에서 수행

### TO-BE


## 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [ ] 테스트 코드
- [x] API 테스트

## ETC.