### PR TITLE
📩 [Task-125] 강의 상세 조회 시 수강신청 여부 반환 및 목록 조회 시 정렬 추가

### DIFF
--- a/src/main/java/com/hanahakdangserver/lecture/controller/LecturesController.java
+++ b/src/main/java/com/hanahakdangserver/lecture/controller/LecturesController.java
@@ -90,23 +90,16 @@ public class LecturesController {
       @PathVariable(value = "lectureId") Long lectureId,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-    LectureDetailDTO result;
-    if (userDetails == null) {
-      result = lecturesService.getLectureDetail(lectureId, AccessRole.NOT_LOGIN,
-          null);
-    } else {
-      List<String> roles = userDetails.getAuthorities()
-          .stream()
-          .map(GrantedAuthority::getAuthority)
-          .toList();
-      if (roles.get(0).equals("ROLE_MENTOR")) {
-        result = lecturesService.getLectureDetail(lectureId, AccessRole.MENTOR,
-            userDetails.getId());
-      } else {
-        result = lecturesService.getLectureDetail(lectureId, AccessRole.MENTEE,
-            userDetails.getId());
-      }
-    }
+    AccessRole accessRole = (userDetails == null)
+        ? AccessRole.NOT_LOGIN
+        : userDetails.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .anyMatch(role -> role.equals("ROLE_MENTOR"))
+            ? AccessRole.MENTOR
+            : AccessRole.MENTEE;
+
+    Long userId = (userDetails != null) ? userDetails.getId() : null;
+    LectureDetailDTO result = lecturesService.getLectureDetail(lectureId, accessRole, userId);
 
     return GET_LECTURE_DETAIL_SUCCESS.createResponseEntity(result);
   }

--- a/src/main/java/com/hanahakdangserver/lecture/dto/LectureDetailDTO.java
+++ b/src/main/java/com/hanahakdangserver/lecture/dto/LectureDetailDTO.java
@@ -68,4 +68,7 @@ public class LectureDetailDTO {
 
   @Schema(description = "강의 썸네일 url", example = "www.hanaro-hanahakdang.com")
   private String thumbnailImgUrl;
+
+  @Schema(description = "수강신청 버튼 활성화 여부; 비로그인 유저&수강신청 안 한 멘티면 NOT_ENROLLED, 멘토는 MENTOR, 수강신청 한 멘티면 ENROLLED", example = "ENROLLED")
+  private String enrollStatus;
 }

--- a/src/main/java/com/hanahakdangserver/lecture/enums/AccessRole.java
+++ b/src/main/java/com/hanahakdangserver/lecture/enums/AccessRole.java
@@ -1,0 +1,14 @@
+package com.hanahakdangserver.lecture.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AccessRole {
+  MENTOR("MENTOR"),
+  NOT_LOGIN("NOT_ENROLLED"),
+  MENTEE("MENTEE");
+
+  private final String status;
+}

--- a/src/main/java/com/hanahakdangserver/lecture/service/LecturesService.java
+++ b/src/main/java/com/hanahakdangserver/lecture/service/LecturesService.java
@@ -60,7 +60,7 @@ public class LecturesService {
    */
   public LecturesResponse getTotalLecturesList(Integer pageNum) {
 
-    PageRequest pageRequest = PageRequest.of(pageNum, PAGE_SIZE);
+    PageRequest pageRequest = PageRequest.of(pageNum, PAGE_SIZE, Sort.by("startTime").ascending());
     Page<Lecture> lectures = lectureRepository.searchAllPossibleLectures(pageRequest);
 
     List<LectureDetailDTO> lectureDetails = lectures.getContent().stream().map(
@@ -76,7 +76,7 @@ public class LecturesService {
   public LecturesResponse getCategoryLecturesList(List<LectureCategory> categoryList,
       Integer pageNum) {
 
-    PageRequest pageRequest = PageRequest.of(pageNum, PAGE_SIZE);
+    PageRequest pageRequest = PageRequest.of(pageNum, PAGE_SIZE, Sort.by("startTime").ascending());
     Page<Lecture> lectures = lectureRepository.searchAllCategoryLectures(pageRequest, categoryList);
 
     List<LectureDetailDTO> lectureDetails = lectures.getContent().stream().map(
@@ -120,7 +120,7 @@ public class LecturesService {
   public MentorLecturesResponse getMentorLecturesList(Integer pageNum, Long mentorId) {
 
     PageRequest pageRequest = PageRequest.of(pageNum, MENTOR_PAGE_SIZE,
-        Sort.by("startTime").descending());
+        Sort.by("startTime").ascending());
 
     Page<Lecture> lectures = lectureRepository.searchAllLecturesOfMentor(pageRequest, mentorId);
 

--- a/src/main/java/com/hanahakdangserver/search/service/SearchService.java
+++ b/src/main/java/com/hanahakdangserver/search/service/SearchService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +30,7 @@ public class SearchService {
 
   public SearchResponse getSearchResult(String keyword, Integer pageNum) {
 
-    PageRequest pageRequest = PageRequest.of(pageNum, PAGE_SIZE);
+    PageRequest pageRequest = PageRequest.of(pageNum, PAGE_SIZE, Sort.by("startTime").ascending());
     Page<Lecture> searchResult = lectureRepository.searchWithKeyword(pageRequest, keyword);
 
     List<LectureResultDetailDTO> lectureResultDetails = searchResult.getContent().stream().map(


### PR DESCRIPTION
## 변경사항

### AS-IS

- **강의 상세 조회 시에 수강신청 여부 반환**
  - LectureDetailDTO에 필드 추가
  ```java
  @Schema(description = "수강신청 버튼 활성화 여부", example = "ENROLLED")
  private String enrollStatus;
  ```
  - 로그인 안 한 유저의 경우, `"NOT_ENROLLED"`
  - 멘토의 경우, `"MENTOR"`
    - 활용 예시) 멘토의 경우 강의 상세 조회 페이지에서 "수강신청" 버튼을 표시하지 않게 함
  - 멘티의 경우, 해당 강의를 수강신청 하지 않았다면 `"NOT_ENROLLED"` / 이미 수강신청한 강의라면 `"ENROLLED"`
- **강의 목록 조회 시에 startTime이 임박한 시간 기준으로 정렬하여 반환**

### TO-BE

[//]: # (해당 PR이 merge 되고 난 후 develop or main 브랜치에 줄 수 있는 영향 설명, 앞으로 할 작업 정리)

## 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [ ] 테스트 코드
- [x] API 테스트

## ETC.